### PR TITLE
Fixed bug where players are unable to remove their own chest protection.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/SignProtection.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignProtection.java
@@ -183,13 +183,18 @@ public class SignProtection extends EssentialsSign
 		SignProtectionState retstate = SignProtectionState.NOSIGN;
 		for (SignProtectionState state : signs.values())
 		{
-			if (state == SignProtectionState.OWNER || state == SignProtectionState.ALLOWED)
+
+			if (state == SignProtectionState.OWNER)
 			{
 				return state;
 			}
-			if (state == SignProtectionState.NOT_ALLOWED)
+			if (state == SignProtectionState.ALLOWED)
 			{
 				retstate = state;
+			}
+			else if (state == SignProtectionState.NOT_ALLOWED && retstate != SignProtectionState.ALLOWED)
+			{
+				retstate = state
 			}
 		}
 		return retstate;


### PR DESCRIPTION
The bug occurs when a chest protection sign has the owner's name on the second line. When removing the protection sign this results in them being labelled as ALLOWED instead of OWNER. They are then unable to remove their own chest protection.

This patch makes sure ownership permissions overrule allowed permissions.
