### PR TITLE
Fires an event before "killing."

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandkill.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkill.java
@@ -23,6 +23,10 @@ public class Commandkill extends EssentialsCommand
 
 		for (Player p : server.matchPlayer(args[0]))
 		{
+			EntityDamageEvent ede = new EntityDamageEvent(p, EntityDamageEvent.DamageCause.CUSTOM, 1000);
+            		server.getPluginManager().callEvent(ede);
+            		//if (ede.isCancelled()) return;
+            		
 			p.setHealth(0);
 			sender.sendMessage(Util.format("kill", p.getDisplayName()));
 		}


### PR DESCRIPTION
Can be made cancel-able.
Could also be written to add "suicide" (if sender == player)

Maybe even, set suicide anyway, even if it's not a suicide? Instead of custom.
