### PR TITLE
No sending to all players, must specify target.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
@@ -21,6 +21,11 @@ public class Commandpay extends EssentialsCommand
 		{
 			throw new NotEnoughArgumentsException();
 		}
+		
+		if (args[0] == "")
+		{
+			throw new NotEnoughArgumentsException("You need to specify a player to pay.");
+		}
 
 		double amount = Double.parseDouble(args[1].replaceAll("[^0-9\\.]", ""));
 


### PR DESCRIPTION
People can send to all players account by providing nothing for the first argument. This pull blocks that.

If you want a different behavior (permission maybe?), now you know. Thanks!
