### PR TITLE
Only change the gamemode of one player per command.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandgamemode.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandgamemode.java
@@ -42,9 +42,7 @@ public class Commandgamemode extends EssentialsCommand
 
 	private void gamemodeOtherPlayers(final Server server, final CommandSender sender, final String[] args)
 	{
-		for (Player matchPlayer : server.matchPlayer(args[0]))
-		{
-			final User player = ess.getUser(matchPlayer);
+			final User player = ess.getUser(server.getPlayer(args[0]));
 			if (player.isHidden())
 			{
 				continue;
@@ -66,6 +64,5 @@ public class Commandgamemode extends EssentialsCommand
 				player.setGameMode(player.getGameMode() == GameMode.SURVIVAL ? GameMode.CREATIVE : GameMode.SURVIVAL);
 			}
 			sender.sendMessage(_("gameMode", _(player.getGameMode().toString().toLowerCase(Locale.ENGLISH)), player.getDisplayName()));
-		}
 	}
 }


### PR DESCRIPTION
Using a For loop with matchPlayer causes the command to match every player on the server. Discovered when an admin newly given creative access on my rival server tried to go creative with /gm 1... and instead gave everyone with a 1 in their name creative. Since he didn't know he could just repeat the command to fix it, things just went from bad to worse for them.
