### PR TITLE
Remove replacements of {} with []

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -333,7 +333,6 @@ public class Settings implements ISettings
 			format = format.replace("{MESSAGE}", "%2$s");
 			format = format.replace("{WORLDNAME}", "{1}");
 			format = format.replace("{SHORTWORLDNAME}", "{2}");
-			format = format.replaceAll("\\{(\\D*?)\\}", "\\[$1\\]");
 			mFormat = new MessageFormat(format);
 			chatFormats.put(group, mFormat);
 		}


### PR DESCRIPTION
It looks like at some point this line was added, but I don't see the point, as it's counter-productive.

https://github.com/phrstbrn/Essentials/commit/d08b1a5089c24d9343d13f6252a7fc27bd694173

It also breaks chat formatting integration with other plugins, so I suggest it be removed.
