### PR TITLE
Fix /vanish with no arguments doing nothing

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -669,6 +669,7 @@ public class User extends UserData implements Comparable<User>, IReplyTo, IUser
 	public void toggleVanished()
 	{
 		final boolean set = !vanished;
+		this.setVanished(set);
 	}
 	
 	public boolean checkSignThrottle() {


### PR DESCRIPTION
The /vanish command got broken so that it was possible to use "/vanish on" and "/vanish off" normally, but just using "'/vanish" to toggle did nothing. This fixes the issue.
