### PR TITLE
Urgent bug fix

### DIFF
--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/permissions/BukkitPermissions.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/permissions/BukkitPermissions.java
@@ -442,18 +442,7 @@ public class BukkitPermissions {
 			updatePermissions(event.getPlayer(), event.getPlayer().getWorld().getName());
 		}
 
-		@EventHandler(priority = EventPriority.LOWEST)
-		public void onPlayerKick(PlayerKickEvent event) {
-
-			Player player = event.getPlayer();
-			
-			/*
-			 * force remove any attachments as bukkit may not
-			 */
-			removeAttachment(player);
-		}
-
-		@EventHandler(priority = EventPriority.LOWEST)
+		@EventHandler(priority = EventPriority.HIGHEST)
 		public void onPlayerQuit(PlayerQuitEvent event) {
 
 			if (!GroupManager.isLoaded())


### PR DESCRIPTION
Permissions are lost too soon for two reasons:

1) Kick event can be cancelled, and even if not cancelled that's a loss before the quit event fires.

2) Quit event on LOWEST means it removes nodes before other quit events fire.
