### PR TITLE
make /gc show END worlds as The End

### DIFF
--- a/Essentials/src/net/ess3/commands/Commandgc.java
+++ b/Essentials/src/net/ess3/commands/Commandgc.java
@@ -35,8 +35,19 @@ public class Commandgc extends EssentialsCommand
 
 		for (World w : server.getWorlds())
 		{
+			String worldType = "World";
+			switch (w.getEnvironment())
+			{
+			case World.Environment.NETHER:
+				worldType = "Nether";
+				break;
+			case World.Environment.THE_END:
+				worldType = "The End";
+				break;
+			}
+
 			sender.sendMessage(
-					(w.getEnvironment() == World.Environment.NETHER ? "Nether" : "World") + " \"" + w.getName() + "\": "
+					worldType + " \"" + w.getName() + "\": "
 					+ w.getLoadedChunks().length + _("gcchunks")
 					+ w.getEntities().size() + _("gcentities"));
 		}


### PR DESCRIPTION
currently END worls show up as "World" because there's only a case for the Nether, with this end worlds are actually shown as being END
