### PR TITLE
Fix how it fail to protect signs and rails and blocks below

### DIFF
--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectBlockListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectBlockListener.java
@@ -54,24 +54,12 @@ public class EssentialsProtectBlockListener implements Listener
 			&& user.isAuthorized("essentials.protect"))
 		{
 			protect.add(blockPlaced);
-			if (prot.getSettingBool(ProtectConfig.protect_below_rails)
-				&& !isProtected(blockPlaced.getRelative(BlockFace.DOWN), user))
-			{
-				protect.add(blockPlaced.getRelative(BlockFace.DOWN));
-			}
 		}
 		if ((blockPlaced.getType() == Material.SIGN_POST || blockPlaced.getType() == Material.WALL_SIGN)
 			&& prot.getSettingBool(ProtectConfig.protect_signs)
 			&& user.isAuthorized("essentials.protect"))
 		{
 			protect.add(blockPlaced);
-			if (prot.getSettingBool(ProtectConfig.protect_against_signs)
-				&& event.getBlockAgainst().getType() != Material.SIGN_POST
-				&& event.getBlockAgainst().getType() != Material.WALL_SIGN
-				&& !isProtected(event.getBlockAgainst(), user))
-			{
-				protect.add(event.getBlockAgainst());
-			}
 		}
 		for (Block block : protect)
 		{
@@ -225,31 +213,7 @@ public class EssentialsProtectBlockListener implements Listener
 
 		if (user.isAuthorized("essentials.protect.admin"))
 		{
-			if (type == Material.WALL_SIGN || type == Material.SIGN_POST || type == Material.RAILS || type == Material.POWERED_RAIL || type == Material.DETECTOR_RAIL)
-			{
-				storage.unprotectBlock(block);
-				if (type == Material.RAILS || type == Material.POWERED_RAIL || type == Material.DETECTOR_RAIL || type == Material.SIGN_POST)
-				{
-					final Block below = block.getRelative(BlockFace.DOWN);
-					storage.unprotectBlock(below);
-				}
-				else
-				{
-					for (BlockFace blockFace : faces)
-					{
-						final Block against = block.getRelative(blockFace);
-						storage.unprotectBlock(against);
-					}
-				}
-			}
-			else
-			{
-				for (BlockFace blockFace : faces)
-				{
-					final Block against = block.getRelative(blockFace);
-					storage.unprotectBlock(against);
-				}
-			}
+			storage.unprotectBlock(block);
 		}
 		else
 		{
@@ -261,31 +225,7 @@ public class EssentialsProtectBlockListener implements Listener
 			}
 			else
 			{
-				if (type == Material.WALL_SIGN || type == Material.SIGN_POST || type == Material.RAILS || type == Material.POWERED_RAIL || type == Material.DETECTOR_RAIL)
-				{
-					storage.unprotectBlock(block);
-					if (type == Material.RAILS || type == Material.POWERED_RAIL || type == Material.DETECTOR_RAIL || type == Material.SIGN_POST)
-					{
-						final Block below = block.getRelative(BlockFace.DOWN);
-						storage.unprotectBlock(below);
-					}
-					else
-					{
-						for (BlockFace blockFace : faces)
-						{
-							final Block against = block.getRelative(blockFace);
-							storage.unprotectBlock(against);
-						}
-					}
-				}
-				else
-				{
-					for (BlockFace blockFace : faces)
-					{
-						final Block against = block.getRelative(blockFace);
-						storage.unprotectBlock(against);
-					}
-				}
+				storage.unprotectBlock(block);
 			}
 		}
 	}
@@ -398,7 +338,7 @@ public class EssentialsProtectBlockListener implements Listener
 				final Block up = block.getRelative(BlockFace.UP);
 				if (up != null && up.getType() == Material.SIGN_POST)
 				{
-					return prot.getStorage().isProtected(block, user.getName());
+					return prot.getStorage().isProtected(up, user.getName());
 				}
 				final BlockFace[] directions = new BlockFace[]
 				{
@@ -415,7 +355,7 @@ public class EssentialsProtectBlockListener implements Listener
 						final org.bukkit.material.Sign signMat = (org.bukkit.material.Sign)signblock.getState().getData();
 						if (signMat != null && signMat.getFacing() == blockFace)
 						{
-							return prot.getStorage().isProtected(block, user.getName());
+							return prot.getStorage().isProtected(signblock, user.getName());
 						}
 					}
 				}
@@ -430,9 +370,11 @@ public class EssentialsProtectBlockListener implements Listener
 			if (prot.getSettingBool(ProtectConfig.protect_below_rails))
 			{
 				final Block up = block.getRelative(BlockFace.UP);
-				if (up != null && (type == Material.RAILS || type == Material.POWERED_RAIL || type == Material.DETECTOR_RAIL))
+				if (up != null)
 				{
-					return prot.getStorage().isProtected(block, user.getName());
+					final Material upType = block.getType();
+					if(upType == Material.RAILS || upType == Material.POWERED_RAIL || upType == Material.DETECTOR_RAIL)
+						return prot.getStorage().isProtected(up, user.getName());
 				}
 			}
 		}

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectBlockListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectBlockListener.java
@@ -355,7 +355,8 @@ public class EssentialsProtectBlockListener implements Listener
 						final org.bukkit.material.Sign signMat = (org.bukkit.material.Sign)signblock.getState().getData();
 						if (signMat != null && signMat.getFacing() == blockFace)
 						{
-							return prot.getStorage().isProtected(signblock, user.getName());
+							if(prot.getStorage().isProtected(signblock, user.getName()))
+								return true;
 						}
 					}
 				}

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectBlockListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectBlockListener.java
@@ -372,7 +372,7 @@ public class EssentialsProtectBlockListener implements Listener
 				final Block up = block.getRelative(BlockFace.UP);
 				if (up != null)
 				{
-					final Material upType = block.getType();
+					final Material upType = up.getType();
 					if(upType == Material.RAILS || upType == Material.POWERED_RAIL || upType == Material.DETECTOR_RAIL)
 						return prot.getStorage().isProtected(up, user.getName());
 				}


### PR DESCRIPTION
Updated isProtected method so it now checks if the sign attached or the rail above is protected.
- It now calls getType on the right block.

Removed storage code for blocks below rails or attached by signs, since we don't need it anymore.
Removed code used to unprotect nearby blocks when a block is being destroyed.
- Said code used to unprotect anything include signs and rails, we don't need the code anymore since we are now checking on the signs and rails themselves.
