### PR TITLE
Cheap kludge to fix the /tpaccept double-charge

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -94,7 +94,8 @@ public abstract class EssentialsCommand implements IEssentialsCommand
 		final Trade charge = new Trade(this.getName(), ess);
 		charge.isAffordableFor(user);
 		run(server, user, commandLabel, args);
-		charge.charge(user);
+		if(!cmd.getName().equalsIgnoreCase("tpaccept"))
+			charge.charge(user);
 	}
 
 	protected void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception


### PR DESCRIPTION
Should we use this just for now so that the tpaccept double charge is fixed? This has already been patched in 3.x. 
