### PR TITLE
Added a total profit message for /sell all|blocks

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
@@ -22,6 +22,9 @@ public class Commandsell extends EssentialsCommand
 	@Override
 	public void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception
 	{
+		double totalWorth = 0.0;
+		double worth = 0.0;
+		String type = "";
 		if (args.length < 1)
 		{
 			throw new NotEnoughArgumentsException();
@@ -41,11 +44,15 @@ public class Commandsell extends EssentialsCommand
 				}
 				try
 				{
-					sellItem(user, stack, args, true);
+					totalWorth += sellItem(user, stack, args, true);				
 				}
 				catch (Exception e)
 				{
 				}
+			}
+			if (totalWorth > 0)
+			{
+				user.sendMessage(_("totalWorthAll", type, Util.displayCurrency(totalWorth, ess)));
 			}
 			return;
 		}
@@ -59,11 +66,15 @@ public class Commandsell extends EssentialsCommand
 				}
 				try
 				{
-					sellItem(user, stack, args, true);
+					totalWorth += sellItem(user, stack, args, true);
 				}
 				catch (Exception e)
 				{
 				}
+			}
+			if (totalWorth > 0)
+			{
+				user.sendMessage(_("totalWorthBlocks", type, Util.displayCurrency(totalWorth, ess)));
 			}
 			return;
 		}
@@ -74,7 +85,7 @@ public class Commandsell extends EssentialsCommand
 		sellItem(user, is, args, false);
 	}
 
-	private void sellItem(User user, ItemStack is, String[] args, boolean isBulkSell) throws Exception
+	private double sellItem(User user, ItemStack is, String[] args, boolean isBulkSell) throws Exception
 	{
 		if (is == null || is.getType() == Material.AIR)
 		{
@@ -149,7 +160,7 @@ public class Commandsell extends EssentialsCommand
 			}
 			else
 			{
-				return;
+				return worth * amount;
 			}
 		}
 
@@ -162,6 +173,6 @@ public class Commandsell extends EssentialsCommand
 		user.giveMoney(worth * amount);
 		user.sendMessage(_("itemSold", Util.displayCurrency(worth * amount, ess), amount, is.getType().toString().toLowerCase(Locale.ENGLISH), Util.displayCurrency(worth, ess)));
 		logger.log(Level.INFO, _("itemSoldConsole", user.getDisplayName(), is.getType().toString().toLowerCase(Locale.ENGLISH), Util.displayCurrency(worth * amount, ess), amount, Util.displayCurrency(worth, ess)));
-
+		return worth * amount;
 	}
 }

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -373,6 +373,8 @@ timeSet=\u00a76Time set in all worlds.
 timeSetPermission=\u00a74You are not authorized to set the time.
 timeWorldCurrent=\u00a76The current time in\u00a7c {0} \u00a76is \u00a7c{1}
 timeWorldSet=\u00a76The time was set to\u00a7c {0} \u00a76in: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=\u00a76Current TPS = {0}
 tradeCompleted=\u00a7aTrade completed.
 tradeSignEmpty=\u00a74The trade sign has nothing available for you.

--- a/Essentials/src/messages_cs.properties
+++ b/Essentials/src/messages_cs.properties
@@ -376,6 +376,8 @@ timeSet=Cas nastaven ve vsech svetech.
 timeSetPermission=\u00a7cNejsi autorizovany ke zmene casu.
 timeWorldCurrent=Ve svete {0} je prave \u00a73{1}
 timeWorldSet=Cas byl nastaven na {0} ve: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Current TPS = {0}
 tradeCompleted=\u00a77Vymena kompletni.
 tradeSignEmpty=Tato cedule jiz nema dostupny material na vymenu.

--- a/Essentials/src/messages_da.properties
+++ b/Essentials/src/messages_da.properties
@@ -373,6 +373,8 @@ timeSet=Tid \u00c3\u00a6ndret i alle verdener.
 timeSetPermission=\u00a7cDu har ikke tilladelse til at \u00c3\u00a6ndre tiden.
 timeWorldCurrent=Tiden p\u00c3\u00a5 nuv\u00c3\u00a6rende tidspunkt i {0} er \u00a73{1}
 timeWorldSet=Tiden blev \u00c3\u00a6ndret til {0} i: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Current TPS = {0}
 tradeCompleted=\u00a77Handel gennemf\u00f8rt.
 tradeSignEmpty=Handelsskiltet har udsolgt!

--- a/Essentials/src/messages_de.properties
+++ b/Essentials/src/messages_de.properties
@@ -373,6 +373,8 @@ timeSet=Zeit in allen Welten gesetzt.
 timeSetPermission=\u00a7cDu hast keine Berechtigung die Zeit zu \u00e4ndern.
 timeWorldCurrent=Die momentane Zeit in {0} ist \u00a73{1}
 timeWorldSet=Die Zeit in \u00a7c{1}\u00a7f wurde zu {0} gesetzt.
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Current TPS = {0}
 tradeCompleted=\u00a77Handel abgeschlossen.
 tradeSignEmpty=Der Bestand des Trade-Schild ist aufgebraucht.

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -373,6 +373,8 @@ timeSet=\u00a76Time set in all worlds.
 timeSetPermission=\u00a74You are not authorized to set the time.
 timeWorldCurrent=\u00a76The current time in\u00a7c {0} \u00a76is \u00a7c{1}
 timeWorldSet=\u00a76The time was set to\u00a7c {0} \u00a76in: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=\u00a76Current TPS = {0}
 tradeCompleted=\u00a7aTrade completed.
 tradeSignEmpty=\u00a74The trade sign has nothing available for you.

--- a/Essentials/src/messages_es.properties
+++ b/Essentials/src/messages_es.properties
@@ -373,6 +373,8 @@ timeSet=Tiempo establecido en todos los mundos.
 timeSetPermission=\u00a7cNo estas autorizado para establecer la hora.
 timeWorldCurrent=La hora actual en {0} es \u00a73{1}
 timeWorldSet=La hora ha sido establecida a {0} en: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=TPS actual = {0}
 tradeCompleted=\u00a77Intercambio completado.
 tradeSignEmpty=Esta tienda no tiene nada disponible para ti.

--- a/Essentials/src/messages_fi.properties
+++ b/Essentials/src/messages_fi.properties
@@ -373,6 +373,8 @@ timeSet=Aika asetettu kaikissa maailmoissa.
 timeSetPermission=\u00a7cSinulla ei ole lupaa vaihtaa aikaa.
 timeWorldCurrent=T\u00e4m\u00e4nhetkinen aika maailmassa {0} on \u00a73{1}
 timeWorldSet=Aika vaihdettiin {0} maailmassa: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=T\u00e4m\u00e4nhetkinen TPS = {0}
 tradeCompleted=\u00a77Vaihto suoritettu.
 tradeSignEmpty=Vaihtokyltill\u00e4 ei ole mit\u00e4\u00e4n tarjolla sinulle.

--- a/Essentials/src/messages_fr.properties
+++ b/Essentials/src/messages_fr.properties
@@ -373,6 +373,8 @@ timeSet=Heure r\u00e9gl\u00e9e dans tous les mondes.
 timeSetPermission=\u00a7cVous n'\u00eates pas autoris\u00e9 \u00e0 r\u00e9gler l'heure.
 timeWorldCurrent=Il est \u00a73{1}\u00a77 dans \u00a7c{0}.
 timeWorldSet=L''heure a \u00e9t\u00e9 r\u00e9gl\u00e9e \u00e0 {0} dans : \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Current TPS = {0}
 tradeCompleted=\u00a77\u00c9change termin\u00e9.
 tradeSignEmpty=Le panneau de vente n'as pas encore assez de stock.

--- a/Essentials/src/messages_it.properties
+++ b/Essentials/src/messages_it.properties
@@ -373,6 +373,8 @@ timeSet=Orario definito in tutti i mondi.
 timeSetPermission=\u00a7cNon sei autorizzato a regolare l''orario.
 timeWorldCurrent=L''orario attuale in {0} e'' \u00a73{1}
 timeWorldSet=L''orario e'' stato regolato alle {0} in: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Current TPS = {0}
 tradeCompleted=\u00a77Affare concluso.
 tradeSignEmpty=L''insegna non dispone di forniture sufficienti.

--- a/Essentials/src/messages_nl.properties
+++ b/Essentials/src/messages_nl.properties
@@ -373,6 +373,8 @@ timeSet=Tijd ingesteld in alle werelden.
 timeSetPermission=\u00a7cJe bent niet bevoegd om de tijd te veranderen.
 timeWorldCurrent=De actuele tijd in {0} is \u00a73{1}
 timeWorldSet=De tijd was veranderd naar {0} in: \u00a7c{1}
+totalWorthAll=\u00a7aAlle spullen verkocht voor een totale waarde van {1}. 
+totalWorthBlocks=\u00a7aAlle blokken verkocht voor een totale waarde van {1}. 
 tps=Huidige TPS = {0}
 tradeCompleted=\u00a77Ruil verricht.
 tradeSignEmpty=Dit handelsbord heeft een te kleine voorraad.

--- a/Essentials/src/messages_pl.properties
+++ b/Essentials/src/messages_pl.properties
@@ -373,6 +373,8 @@ timeSet=Czas ustawiono we wszystkich swiatach.
 timeSetPermission=\u00a7cNie masz uprawnien do ustawiania czasu.
 timeWorldCurrent=Obecny czas {0} to \u00a73{1}.
 timeWorldSet=Czas ustawiono {0} w: \u00a7c{1}.
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Current TPS = {0}
 tradeCompleted=\u00a77Handel zakonczono.
 tradeSignEmpty=Tabliczka handlowa nie jest dostepna dla Ciebie.

--- a/Essentials/src/messages_pt.properties
+++ b/Essentials/src/messages_pt.properties
@@ -373,6 +373,8 @@ timeSet=Horario definido em todos os mundos.
 timeSetPermission=\u00a7cVoc\u00ea nao tem autoriza\u00e7ao para modificar o hor\u00e1rio.
 timeWorldCurrent=O hor\u00e1rio atual no mundo {0} e \u00a73{1}
 timeWorldSet=O hor\u00e1rio foi definido para {0} no: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Current TPS = {0}
 tradeCompleted=\u00a77Compra concluida.
 tradeSignEmpty=A placa de troca nao tem abastecimento suficiente.

--- a/Essentials/src/messages_se.properties
+++ b/Essentials/src/messages_se.properties
@@ -373,6 +373,8 @@ timeSet=Tid inst\u00e4lld i alla v\u00e4rldar.
 timeSetPermission=\u00a7cDu har inte tillst\u00e5nd att st\u00e4lla in tiden.
 timeWorldCurrent=Den nuvarande tiden i {0} \u00e4r \u00a73{1}
 timeWorldSet=Tiden \u00e4r nu {0} i: \u00a7c{1}
+totalWorthAll=\u00a7aSold all items and blocks for a total worth of {1}. 
+totalWorthBlocks=\u00a7aSold all blocks for a total worth of {1}. 
 tps=Nuvarande TPS = {0}
 tradeCompleted=\u00a77K\u00f6p avslutat.
 tradeSignEmpty=K\u00f6pskylten har inget tillg\u00e4ngligt f\u00f6r dig.


### PR DESCRIPTION
It shows a message after issueing the /sell command in bulk saying how much the total profit of everything you sold is.
ex.

Sold all blocks and items for a total worth of $5000.
