### PR TITLE
Store enchanments in Enchanted Books

### DIFF
--- a/Essentials/src/net/ess3/commands/Commandenchant.java
+++ b/Essentials/src/net/ess3/commands/Commandenchant.java
@@ -1,6 +1,7 @@
 package net.ess3.commands;
 
 import static net.ess3.I18n._;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
Enchantments need to be stored in Enchanted Books to be able to use them on the anvil.

Change enchant command to store the enchantment instead of applying it when used on an Enchanted Book.  If an enchantment is already present, replace it (only one allowed on Enchanted Books).
