### PR TITLE
Store enchantments in Enchanted Books

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ItemDb.java
+++ b/Essentials/src/com/earth2me/essentials/ItemDb.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
 
 public class ItemDb implements IConf, IItemDb


### PR DESCRIPTION
Enchantments needs to be stored in Enchanted Books to be able to use them on the anvil.

Change ItemDb's addEnchantment method to store the enchantment instead of applying it when used on an Enchanted Book.  If an enchantment is already present, replace it (only one allowed on Enchanted Books).
