### PR TITLE
Prevent replacement of { and } characters in chat.format

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -415,7 +415,8 @@ public class Settings implements ISettings
 			format = format.replace("{MESSAGE}", "%2$s");
 			format = format.replace("{WORLDNAME}", "{1}");
 			format = format.replace("{SHORTWORLDNAME}", "{2}");
-			format = format.replaceAll("\\{(\\D*?)\\}", "\\[$1\\]");
+			format = format.replaceAll("'", "''");
+			format = format.replaceAll("\\{(\\D*?)\\}", "\\'{$1\\}'");
 			format = "§r".concat(format);
 			mFormat = new MessageFormat(format);
 			chatFormats.put(group, mFormat);


### PR DESCRIPTION
This will prevent any { and } characters from being replaced with brackets [], and should not cause MessageFormat to bomb.
