### PR TITLE
Prevent replacement of {\d+} sequences in chat.format and remove stray '

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -410,13 +410,15 @@ public class Settings implements ISettings
 			String format = config.getString("chat.group-formats." + (group == null ? "Default" : group),
 											 config.getString("chat.format", "&7[{GROUP}]&f {DISPLAYNAME}&7:&f {MESSAGE}"));
 			format = Util.replaceFormat(format);
+			format = format.replaceAll("'", "''"); // escape quotes
+			format = format.replaceAll("\\{(\\d+)\\}", "'{'$1'}'"); // quote {\d+} sequences
 			format = format.replace("{DISPLAYNAME}", "%1$s");
 			format = format.replace("{GROUP}", "{0}");
 			format = format.replace("{MESSAGE}", "%2$s");
 			format = format.replace("{WORLDNAME}", "{1}");
 			format = format.replace("{SHORTWORLDNAME}", "{2}");
-			format = format.replaceAll("'", "''");
-			format = format.replaceAll("\\{(\\D*?)\\}", "\\'{$1\\}'");
+			format = format.replaceAll("(?:^|(?<=[^\\d'])|(?<=\\d'\\}'))([{}][{}']*)(?:$|(?=[^\\d'])|(?<='\\{'\\d))", "'$1'"); // quote the rest of the braces
+			format = format.replaceAll("'([}{])''('*)([}{])'", "'$1$2$3'"); // cleanup extra ''
 			format = "§r".concat(format);
 			mFormat = new MessageFormat(format);
 			chatFormats.put(group, mFormat);


### PR DESCRIPTION
This fixes issues presented by khobbits with the latest chat.format brace fix.

https://github.com/phrstbrn/Essentials/commit/8fde5102b9161cda2267d3638c15dc6fda48a7fd#commitcomment-2494321

Unfortunately the regex to fix it is gross (and largely unreadable), however, it does fix the issue and a few other edge cases.
