### PR TITLE
Prevent replacement of { and } in chat.format

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -410,12 +410,15 @@ public class Settings implements ISettings
 			String format = config.getString("chat.group-formats." + (group == null ? "Default" : group),
 											 config.getString("chat.format", "&7[{GROUP}]&f {DISPLAYNAME}&7:&f {MESSAGE}"));
 			format = Util.replaceFormat(format);
-			format = format.replace("{DISPLAYNAME}", "%1$s");
-			format = format.replace("{GROUP}", "{0}");
-			format = format.replace("{MESSAGE}", "%2$s");
-			format = format.replace("{WORLDNAME}", "{1}");
-			format = format.replace("{SHORTWORLDNAME}", "{2}");
-			format = format.replaceAll("\\{(\\D*?)\\}", "\\[$1\\]");
+			format = format.replace("'", "''");
+			format = format.replace("{", "'{'");
+			format = format.replace("}", "'}'");
+			format = format.replace("'{'DISPLAYNAME'}'", "%1$s");
+			format = format.replace("'{'GROUP'}'", "{0}");
+			format = format.replace("'{'MESSAGE'}'", "%2$s");
+			format = format.replace("'{'WORLDNAME'}'", "{1}");
+			format = format.replace("'{'SHORTWORLDNAME'}'", "{2}");
+			format = format.replaceAll("(?<='[{}]{0,99})([{}])''('*)(?=[{}]')", "$1$2"); // remove extra '' between braces
 			format = "§r".concat(format);
 			mFormat = new MessageFormat(format);
 			chatFormats.put(group, mFormat);


### PR DESCRIPTION
This is a refinement of the combination of these two pull requests.  It performs the same functionality, but doesn't require gross regex to pull off.

https://github.com/essentials/Essentials/pull/284
https://github.com/essentials/Essentials/pull/285
