### PR TITLE
Patch ticket #3706

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -140,7 +140,10 @@ public class EssentialsPlayerListener implements Listener
 		}
 		if (!user.isJailed())
 		{
-			user.setLastLocation();
+			if (user.isAuthorized("essentials.back.ondeath") || user.isAlive)
+			{
+				user.setLastLocation();
+			}
 		}
 		if (user.isRecipeSee())
 		{


### PR DESCRIPTION
Dont set last location if player is dead and doesnt have permission for essentials.back.ondeath, prevents exploit with /back.
