### PR TITLE
Add methods to UserData and IUser for accessing and writing of data from other plugins.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/IUser.java
+++ b/Essentials/src/com/earth2me/essentials/IUser.java
@@ -1,6 +1,8 @@
 package com.earth2me.essentials;
 
 import com.earth2me.essentials.commands.IEssentialsCommand;
+import java.util.Map;
+import java.util.Set;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -52,4 +54,12 @@ public interface IUser extends Player
 	void setLogoutLocation();
 	
 	Location getLogoutLocation();
+	
+	void setConfigProperty(String node, Object object);
+	
+	Set<String> getConfigKeys();
+	
+	Map<String, Object> getConfigMap();
+	
+	Map<String, Object> getConfigMap(String node);
 }

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -867,6 +867,60 @@ public abstract class UserData extends PlayerExtension implements IConf
 		config.save();
 	}
 
+	public void setConfigProperty(String node, Object object)
+    {
+        final String prefix = "info.";
+        node = prefix+node;
+        if (object instanceof Map)
+        {
+            config.setProperty(node, (Map) object);
+        }
+        else if (object instanceof List)
+        {
+            config.setProperty(node, (List<String>) object);
+        }
+        else if (object instanceof Location)
+        {
+            config.setProperty(node, (Location) object);
+        }
+        else if (object instanceof ItemStack)
+        {
+            config.setProperty(node, (ItemStack) object);
+        }
+        else
+        {
+            config.setProperty(node, object);
+        }
+        config.save();
+    }
+	
+	public Set<String> getConfigKeys()
+	{
+		if (config.isConfigurationSection("info"))
+		{
+			return config.getConfigurationSection("info").getKeys(true);
+		}
+		return new HashSet<String>();
+	}
+	
+	public Map<String, Object> getConfigMap()
+	{
+		if (config.isConfigurationSection("info"))
+		{
+			return config.getConfigurationSection("info").getValues(true);
+		}
+		return new HashMap<String, Object>();
+	}
+	
+	public Map<String, Object> getConfigMap(String node)
+	{
+		if (config.isConfigurationSection("info."+node))
+		{
+			return config.getConfigurationSection("info."+node).getValues(true);
+		}
+		return new HashMap<String, Object>();
+	}
+	
 	public void save()
 	{
 		config.save();


### PR DESCRIPTION
This gives plugins access to a node called "info" in the UserData yaml, this allows for plugins to easily read and write data to the userdata without fighting with Essentials over a file.
