### PR TITLE
Fixed 1.5 wool crashing client if calling /item wool:16 or higher

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commanditem.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanditem.java
@@ -66,6 +66,11 @@ public class Commanditem extends EssentialsCommand
 		}
 
 
+		if (stack.getType() == Material.WOOL && (stack.getDurability() < 0 || stack.getDurability() > 15))
+		{
+			throw new Exception(_("cantSpawnItem", "Wool"));
+		}
+		
 		if (stack.getType() == Material.AIR)
 		{
 			throw new Exception(_("cantSpawnItem", "Air"));


### PR DESCRIPTION
Using the command /i wool:16 will crash the client.  The players dat file will have to be deleted for them to log back in.  This is a work around until Mojang fixes.
