### PR TITLE
[Fix] Strip colourcodes from groups in /list (internal only)

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
@@ -73,7 +73,7 @@ public class Commandlist extends EssentialsCommand
 			{
 				continue;
 			}
-			final String group = onlineUser.getGroup().toLowerCase();
+			final String group = Util.stripFormat(onlineUser.getGroup().toLowerCase());
 			List<User> list = playerList.get(group);
 			if (list == null)
 			{


### PR DESCRIPTION
This way groups with colourcodes in the middle of the name work with /who <groupname> ie. §4S§cerveradmin
