### PR TITLE
Made the "throws" declaration of getWarps() more specific

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsConf.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsConf.java
@@ -1,6 +1,8 @@
 package com.earth2me.essentials;
 
 import static com.earth2me.essentials.I18n._;
+
+import com.earth2me.essentials.api.InvalidWorldException;
 import com.google.common.io.Files;
 import java.io.*;
 import java.nio.ByteBuffer;
@@ -379,7 +381,7 @@ public class EssentialsConf extends YamlConfiguration
 		return isSet(path);
 	}
 
-	public Location getLocation(final String path, final Server server) throws Exception
+	public Location getLocation(final String path, final Server server) throws InvalidWorldException
 	{
 		final String worldName = getString((path == null ? "" : path + ".") + "world");
 		if (worldName == null || worldName.isEmpty())
@@ -389,7 +391,7 @@ public class EssentialsConf extends YamlConfiguration
 		final World world = server.getWorld(worldName);
 		if (world == null)
 		{
-			throw new Exception(_("invalidWorld"));
+			throw new InvalidWorldException(worldName);
 		}
 		return new Location(world,
 							getDouble((path == null ? "" : path + ".") + "x", 0),

--- a/Essentials/src/com/earth2me/essentials/Warps.java
+++ b/Essentials/src/com/earth2me/essentials/Warps.java
@@ -3,6 +3,7 @@ package com.earth2me.essentials;
 import static com.earth2me.essentials.I18n._;
 import com.earth2me.essentials.api.IWarps;
 import com.earth2me.essentials.api.InvalidNameException;
+import com.earth2me.essentials.api.InvalidWorldException;
 import com.earth2me.essentials.commands.WarpNotFoundException;
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +50,7 @@ public class Warps implements IConf, IWarps
 	}
 
 	@Override
-	public Location getWarp(String warp) throws Exception
+	public Location getWarp(String warp) throws WarpNotFoundException, InvalidWorldException
 	{
 		EssentialsConf conf = warpPoints.get(new StringIgnoreCase(warp));
 		if (conf == null)

--- a/Essentials/src/com/earth2me/essentials/api/IWarps.java
+++ b/Essentials/src/com/earth2me/essentials/api/IWarps.java
@@ -2,6 +2,8 @@ package com.earth2me.essentials.api;
 
 import java.io.File;
 import java.util.Collection;
+
+import com.earth2me.essentials.commands.WarpNotFoundException;
 import org.bukkit.Location;
 
 
@@ -12,9 +14,10 @@ public interface IWarps
 	 *
 	 * @param warp - Warp name
 	 * @return - Location the warp is set to
-	 * @throws Exception
+	 * @throws WarpNotFoundException When the warp is not found
+	 * @throws InvalidWorldException When the world the warp is in is not found
 	 */
-	Location getWarp(String warp) throws Exception;
+	Location getWarp(String warp) throws WarpNotFoundException, InvalidWorldException;
 
 	/**
 	 * Gets a list of warps

--- a/Essentials/src/com/earth2me/essentials/api/InvalidWorldException.java
+++ b/Essentials/src/com/earth2me/essentials/api/InvalidWorldException.java
@@ -1,0 +1,16 @@
+package com.earth2me.essentials.api;
+
+import static com.earth2me.essentials.I18n._;
+
+public class InvalidWorldException extends Exception {
+	private final String world;
+
+	public InvalidWorldException(final String world) {
+		super(_("invalidWorld"));
+		this.world = world;
+	}
+
+	public String getWorld() {
+		return this.world;
+	}
+}


### PR DESCRIPTION
It is very difficult to handle an Exception thrown by an API method when you don't have any way to **programatically** (without dirty stuff like string comparisons, so the message is not enough) distinguish errors and find out what's going on.
