### PR TITLE
Using the /home command shouldn't trigger a PlayerRespawnEvent

### DIFF
--- a/Essentials/src/net/ess3/Teleport.java
+++ b/Essentials/src/net/ess3/Teleport.java
@@ -292,8 +292,7 @@ public class Teleport implements Runnable, ITeleport
 	public void respawn(final Trade chargeFor, TeleportCause cause) throws Exception
 	{
 		final Location bed = user.getBedSpawnLocation();
-		final Location respawnLoc = ess.getPlugin().callRespawnEvent(
-				user.getPlayer(), bed == null ? user.getPlayer().getWorld().getSpawnLocation() : bed, bed != null);
+		final Location respawnLoc = bed == null ? user.getPlayer().getWorld().getSpawnLocation() : bed;
 		teleport(new Target(respawnLoc), chargeFor, cause);
 	}
 


### PR DESCRIPTION
Currently when using /home and no bed or home is present a Player will be teleported to the world spawn and a PlayerRespawnEvent is called.

Imo the PlayerRespawnEvent should only be called when a Player has died and is actually respawning at spawn/bed/home. 

I use the PlayerRespawnEvent in my plugin to change the default amount of food and health a Player has when he respawns. Using /home without a bed triggers the Event which takes food/health away from the teleporting Player.
