### PR TITLE
Alert give sender that the user was unable to receive all items.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandgive.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandgive.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.Util;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
 import java.util.Locale;
+import java.util.Map;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
@@ -72,14 +73,14 @@ public class Commandgive extends EssentialsCommand
 		if (args.length > 3)
 		{
 			MetaItemStack metaStack = new MetaItemStack(stack);
-			boolean allowUnsafe = ess.getSettings().allowUnsafeEnchantments();			
+			boolean allowUnsafe = ess.getSettings().allowUnsafeEnchantments();
 			if (allowUnsafe && sender instanceof Player && !ess.getUser(sender).isAuthorized("essentials.enchantments.allowunsafe"))
 			{
 				allowUnsafe = false;
 			}
-			
+
 			metaStack.parseStringMeta(sender, allowUnsafe, args, Util.isInt(args[3]) ? 4 : 3, ess);
-			
+
 			stack = metaStack.getItemStack();
 		}
 
@@ -90,14 +91,23 @@ public class Commandgive extends EssentialsCommand
 
 		final String itemName = stack.getType().toString().toLowerCase(Locale.ENGLISH).replace('_', ' ');
 		sender.sendMessage(_("giveSpawn", stack.getAmount(), itemName, giveTo.getDisplayName()));
+
+		Map<Integer, ItemStack> leftovers;
+
 		if (giveTo.isAuthorized("essentials.oversizedstacks"))
 		{
-			InventoryWorkaround.addOversizedItems(giveTo.getInventory(), ess.getSettings().getOversizedStackSize(), stack);
+			leftovers = InventoryWorkaround.addOversizedItems(giveTo.getInventory(), ess.getSettings().getOversizedStackSize(), stack);
 		}
 		else
 		{
-			InventoryWorkaround.addItems(giveTo.getInventory(), stack);
+			leftovers = InventoryWorkaround.addItems(giveTo.getInventory(), stack);
 		}
+
+		for (ItemStack item: leftovers.values())
+		{
+			sender.sendMessage(_("giveSpawnFailure", item.getAmount(), itemName, giveTo.getDisplayName()));
+		}
+
 		giveTo.updateInventory();
 	}
 }

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -134,6 +134,7 @@ geoIpUrlEmpty=GeoIP download url is empty.
 geoIpUrlInvalid=GeoIP download url is invalid.
 geoipJoinFormat=\u00a76Player \u00a7c{0} \u00a76comes from \u00a7c{1}\u00a76.
 giveSpawn=\u00a76Giving\u00a7c {0} \u00a76of\u00a7c {1} to\u00a7c {2}\u00a76.
+giveSpawnFailure=\u00a76Failed to give\u00a7c {0} \u00a76of\u00a7c {1} to\u00a7c {2}\u00a76.
 godDisabledFor=\u00a74disabled\u00a76 for\u00a7c {0}
 godEnabledFor=\u00a7aenabled\u00a76 for\u00a7c {0}
 godMode=\u00a76God mode\u00a7c {0}\u00a76.


### PR DESCRIPTION
Currently there is no output to indicate if a user was able to receive the items or if their inventory was full. When used in conjunction with buycraft often a players inventory can overflow making more work for a admin to verify infact that they did not get the items.

This pr does two things:
1)Add a new message indicating that there was a failure in providing the items
2)Display the following to the sender of the command: Failure of command, # of items that could not be give, and the items that could not be given.
