### PR TITLE
Changing a spawner should update its BlockState.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandspawner.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandspawner.java
@@ -66,6 +66,7 @@ public class Commandspawner extends EssentialsCommand
 			CreatureSpawner spawner = (CreatureSpawner)target.getBlock().getState();
 			spawner.setSpawnedType(mob.getType());
 			spawner.setDelay(delay);
+			spawner.update();
 		}
 		catch (Throwable ex)
 		{


### PR DESCRIPTION
This pull request changes the `spawner` command to update the state of the spawner so that nearby players can instantly see the new type of mob floating inside the spawner (as opposed to having to re-render the spawner to do so).
