### PR TITLE
[Add] Permission for SocialSpy exempt

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -401,7 +401,11 @@ public class EssentialsPlayerListener implements Listener
 				final User spyer = ess.getUser(onlinePlayer);
 				if (spyer.isSocialSpyEnabled() && !player.equals(onlinePlayer))
 				{
-					onlinePlayer.sendMessage(player.getDisplayName() + " : " + event.getMessage());
+					User user = ess.getUser(player);
+					if (!user.isAuthorized("essentials.socialspy.exempt") 
+					{
+						onlinePlayer.sendMessage(player.getDisplayName() + " : " + event.getMessage());
+					}
 				}
 			}
 		}

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -404,7 +404,7 @@ public class EssentialsPlayerListener implements Listener
 					User user = ess.getUser(player);
 					if (!user.isAuthorized("essentials.socialspy.exempt") 
 					{
-						onlinePlayer.sendMessage(player.getDisplayName() + " : " + event.getMessage());
+						onlinePlayer.sendMessage(ChatColor.GRAY + "[Spy] " + player.getDisplayName() + ":" + event.getMessage());
 					}
 				}
 			}


### PR DESCRIPTION
Adds permission essentials.socialspy.exempt so that players are exempt from socialspy.

Also adds the prefix [Spy] to the beginning of all social spy messages.
