### PR TITLE
Commented out the "all_unnamed_world" section.

### DIFF
--- a/EssentialsGroupManager/src/config.yml
+++ b/EssentialsGroupManager/src/config.yml
@@ -38,9 +38,9 @@ settings:
           world_the_end:
           - users
           - groups
-          all_unnamed_worlds:
-          - users
-          - groups
+         # all_unnamed_worlds:
+         # - users
+         # - groups
     #  world2:      (World2 would have it's own set of user and groups files)
     #    world3:
     #    - users    (World3 would use the users.yml from world2, but it's own groups.yml)


### PR DESCRIPTION
Many people have complained about world folders not generating. 
I don't believe mirroring for all worlds to the main world should be enabled by default, especially if the main world isn't "world."
If lines 34-43 are meant to simply be an example, they should probably be commented out just like lines 44-50.
p.s.idkwatimdoingihopeididthisright
