### PR TITLE
Add space in between group name and first user

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
@@ -264,7 +264,7 @@ public class Commandlist extends EssentialsCommand
 	{
 		final StringBuilder outputString = new StringBuilder();
 		outputString.append(_("listGroupTag", FormatUtil.replaceFormat(group)));
-		outputString.append(message);
+		outputString.append(" " + message);
 		outputString.setCharAt(0, Character.toTitleCase(outputString.charAt(0)));
 		return outputString.toString();
 	}


### PR DESCRIPTION
I know this isn't a very major change, but it bugs me whenever i type /list :P
