### PR TITLE
Fix colourcode problems in /list <groupname>

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
@@ -74,7 +74,7 @@ public class Commandlist extends EssentialsCommand
 			{
 				continue;
 			}
-			final String group = FormatUtil.stripFormat(onlineUser.getGroup().toLowerCase());
+			final String group = FormatUtil.stripFormat(ChatColor.translateAlternateColorCodes('&',onlineUser.getGroup().toLowerCase()));
 			List<User> list = playerList.get(group);
 			if (list == null)
 			{


### PR DESCRIPTION
It didn't do groups with & colourcodes inside it, like &0_&6T&2y&6c&2o&6o&2n&0_&6, I had to type /list &0_&6T&2y&6c&2o&6o&2n&0_&6 instead of /list *tycoon*
