### PR TITLE
big mistake! /pong -> Pong? Thats wrong!

### DIFF
--- a/Essentials/src/net/ess3/commands/Commandping.java
+++ b/Essentials/src/net/ess3/commands/Commandping.java
@@ -12,7 +12,15 @@ public class Commandping extends EssentialsCommand
 	{
 		if (args.length < 1)
 		{
-			user.sendMessage(_("Pong!"));
+			
+			if (commandLabel.equalsIgnoreCase("pong") || commandLabel.equalsIgnoreCase("epong") ) 
+			{
+				user.sendMessage(_("Ping!"));
+			} 
+			else 
+			{
+				user.sendMessage(_("Pong!"));
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Ping > Pong! - Ok
Pong > Pong! - Holy shit?
That´s better: Pong > Ping!
