### PR TITLE
Check if a KickMessage is given before you load your own one

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -319,6 +319,11 @@ public class EssentialsPlayerListener implements Listener
 			final boolean banExpired = user.checkBanTimeout(System.currentTimeMillis());
 			if (!banExpired)
 			{
+				if (!event.getKickMessage().equals("")) 
+				{
+					return;
+				}
+				
 				String banReason = user.getBanReason();
 				if (banReason == null || banReason.isEmpty() || banReason.equalsIgnoreCase("ban"))
 				{


### PR DESCRIPTION
The PlayerLoginEvent has no cancel state. So the Event will go through all Listeners attached to it. If a Plugin sets a KickMessage before it gets to Essentials, Essentials will ignore the KickMessage and tries to load its message.

This commit will check if there is a message set. If yes the processing of this event will be skipped.

CraftBukkit Code: https://github.com/Bukkit/CraftBukkit/blob/a9fc0f19d9ba24e91cf295e0674d7f6adba1de70/src/main/java/net/minecraft/server/PlayerList.java#L334

Bukkkit PlayerLoginEvent:
https://github.com/Bukkit/Bukkit/blob/3f706a658acd1759bfed41f1485c4adc12980e69/src/main/java/org/bukkit/event/player/PlayerLoginEvent.java
