### PR TITLE
[feature] Add XMPP presence and description support for current game status with Essentials XMPP

### DIFF
--- a/EssentialsXMPP/src/com/earth2me/essentials/xmpp/EssentialsXMPP.java
+++ b/EssentialsXMPP/src/com/earth2me/essentials/xmpp/EssentialsXMPP.java
@@ -16,130 +16,137 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class EssentialsXMPP extends JavaPlugin implements IEssentialsXMPP
 {
-	private static final Logger LOGGER = Logger.getLogger("Minecraft");
-	private static EssentialsXMPP instance = null;
-	private transient UserManager users;
-	private transient XMPPManager xmpp;
-	private transient IEssentials ess;
+        private static final Logger LOGGER = Logger.getLogger("Minecraft");
+        private static EssentialsXMPP instance = null;
+        private transient UserManager users;
+        private transient XMPPManager xmpp;
+        private transient IEssentials ess;
 
-	public static IEssentialsXMPP getInstance()
-	{
-		return instance;
-	}
+        public static IEssentialsXMPP getInstance()
+        {
+                return instance;
+        }
 
-	@Override
-	public void onEnable()
-	{
-		instance = this;
+        @Override
+        public void onEnable()
+        {
+                instance = this;
 
-		final PluginManager pluginManager = getServer().getPluginManager();
-		ess = (IEssentials)pluginManager.getPlugin("Essentials");
-		if (!this.getDescription().getVersion().equals(ess.getDescription().getVersion()))
-		{
-			LOGGER.log(Level.WARNING, _("versionMismatchAll"));
-		}
-		if (!ess.isEnabled())
-		{
-			this.setEnabled(false);
-			return;
-		}
+                final PluginManager pluginManager = getServer().getPluginManager();
+                ess = (IEssentials)pluginManager.getPlugin("Essentials");
+                if (!this.getDescription().getVersion().equals(ess.getDescription().getVersion()))
+                {
+                        LOGGER.log(Level.WARNING, _("versionMismatchAll"));
+                }
+                if (!ess.isEnabled())
+                {
+                        this.setEnabled(false);
+                        return;
+                }
 
-		final EssentialsXMPPPlayerListener playerListener = new EssentialsXMPPPlayerListener(ess);
-		pluginManager.registerEvents(playerListener, this);
+                final EssentialsXMPPPlayerListener playerListener = new EssentialsXMPPPlayerListener(ess);
+                pluginManager.registerEvents(playerListener, this);
 
-		users = new UserManager(this.getDataFolder());
-		xmpp = new XMPPManager(this);
+                users = new UserManager(this.getDataFolder());
+                xmpp = new XMPPManager(this);
 
-		ess.addReloadListener(users);
-		ess.addReloadListener(xmpp);
-	}
+                ess.addReloadListener(users);
+                ess.addReloadListener(xmpp);
+        }
 
-	@Override
-	public void onDisable()
-	{
-		if (xmpp != null)
-		{
-			xmpp.disconnect();
-		}
-		instance = null;
-	}
+        @Override
+        public void onDisable()
+        {
+                if (xmpp != null)
+                {
+                        xmpp.disconnect();
+                }
+                instance = null;
+        }
 
-	@Override
-	public boolean onCommand(final CommandSender sender, final Command command, final String commandLabel, final String[] args)
-	{
-		return ess.onCommandEssentials(sender, command, commandLabel, args, EssentialsXMPP.class.getClassLoader(), "com.earth2me.essentials.xmpp.Command", "essentials.", null);
-	}
+        @Override
+        public boolean onCommand(final CommandSender sender, final Command command, final String commandLabel, final String[] args)
+        {
+                return ess.onCommandEssentials(sender, command, commandLabel, args, EssentialsXMPP.class.getClassLoader(), "com.earth2me.essentials.xmpp.Command", "essentials.", null);
+        }
 
-	@Override
-	public void setAddress(final Player user, final String address)
-	{
-		final String username = user.getName().toLowerCase(Locale.ENGLISH);
-		instance.users.setAddress(username, address);
-	}
+        @Override
+        public void setAddress(final Player user, final String address)
+        {
+                final String username = user.getName().toLowerCase(Locale.ENGLISH);
+                instance.users.setAddress(username, address);
+        }
 
-	@Override
-	public String getAddress(final String name)
-	{
-		return instance.users.getAddress(name);
-	}
+        @Override
+        public String getAddress(final String name)
+        {
+                return instance.users.getAddress(name);
+        }
 
-	@Override
-	public IUser getUserByAddress(final String address)
-	{
-		String username = instance.users.getUserByAddress(address);
-		return username == null ? null : ess.getUser(username);
-	}
+        @Override
+        public IUser getUserByAddress(final String address)
+        {
+                String username = instance.users.getUserByAddress(address);
+                return username == null ? null : ess.getUser(username);
+        }
 
-	@Override
-	public boolean toggleSpy(final Player user)
-	{
-		final String username = user.getName().toLowerCase(Locale.ENGLISH);
-		final boolean spy = !instance.users.isSpy(username);
-		instance.users.setSpy(username, spy);
-		return spy;
-	}
+        @Override
+        public boolean toggleSpy(final Player user)
+        {
+                final String username = user.getName().toLowerCase(Locale.ENGLISH);
+                final boolean spy = !instance.users.isSpy(username);
+                instance.users.setSpy(username, spy);
+                return spy;
+        }
 
-	@Override
-	public String getAddress(final Player user)
-	{
-		return instance.users.getAddress(user.getName());
-	}
+        @Override
+        public String getAddress(final Player user)
+        {
+                return instance.users.getAddress(user.getName());
+        }
 
-	@Override
-	public boolean sendMessage(final Player user, final String message)
-	{
-		return instance.xmpp.sendMessage(instance.users.getAddress(user.getName()), message);
-	}
+        @Override
+        public boolean sendMessage(final Player user, final String message)
+        {
+                return instance.xmpp.sendMessage(instance.users.getAddress(user.getName()), message);
+        }
 
-	@Override
-	public boolean sendMessage(final String address, final String message)
-	{
-		return instance.xmpp.sendMessage(address, message);
-	}
+        @Override
+        public boolean sendMessage(final String address, final String message)
+        {
+                return instance.xmpp.sendMessage(address, message);
+        }
 
-	@Override
-	public List<String> getSpyUsers()
-	{
-		return instance.users.getSpyUsers();
-	}
+        // @Override
+        public static boolean updatePresence()
+        {
+                instance.xmpp.updatePresence();
+                return true;
+        }
 
-	@Override
-	public void broadcastMessage(final IUser sender, final String message, final String xmppAddress)
-	{
-		ess.broadcastMessage(sender, message);
-		try
-		{
-			for (String address : getSpyUsers())
-			{
-				if (!address.equalsIgnoreCase(xmppAddress))
-				{
-					sendMessage(address, message);
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-			// Ignore exceptions
-		}
-	}
+        @Override
+        public List<String> getSpyUsers()
+        {
+                return instance.users.getSpyUsers();
+        }
+
+        @Override
+        public void broadcastMessage(final IUser sender, final String message, final String xmppAddress)
+        {
+                ess.broadcastMessage(sender, message);
+                try
+                {
+                        for (String address : getSpyUsers())
+                        {
+                                if (!address.equalsIgnoreCase(xmppAddress))
+                                {
+                                        sendMessage(address, message);
+                                }
+                        }
+                }
+                catch (Exception ex)
+                {
+                        // Ignore exceptions
+                }
+        }
 }

--- a/EssentialsXMPP/src/com/earth2me/essentials/xmpp/EssentialsXMPPPlayerListener.java
+++ b/EssentialsXMPP/src/com/earth2me/essentials/xmpp/EssentialsXMPPPlayerListener.java
@@ -3,6 +3,9 @@ package com.earth2me.essentials.xmpp;
 import com.earth2me.essentials.IEssentials;
 import com.earth2me.essentials.User;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.ess3.api.IUser;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -10,64 +13,86 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.Server;
 
 
 class EssentialsXMPPPlayerListener implements Listener
 {
-	private final transient IEssentials ess;
+        private final transient IEssentials ess;
 
-	EssentialsXMPPPlayerListener(final IEssentials ess)
-	{
-		super();
-		this.ess = ess;
-	}
+        EssentialsXMPPPlayerListener(final IEssentials ess)
+        {
+                super();
+                this.ess = ess;
+        }
 
-	@EventHandler(priority = EventPriority.MONITOR)
-	public void onPlayerJoin(final PlayerJoinEvent event)
-	{
-		final User user = ess.getUser(event.getPlayer());
-		sendMessageToSpyUsers("Player " + user.getDisplayName() + " joined the game");
-	}
+        @EventHandler(priority = EventPriority.MONITOR)
+        public void onPlayerJoin(final PlayerJoinEvent event)
+        {
+                final User user = ess.getUser(event.getPlayer());
 
-	@EventHandler(priority = EventPriority.MONITOR)
-	public void onPlayerChat(final AsyncPlayerChatEvent event)
-	{
-		final User user = ess.getUser(event.getPlayer());
-		sendMessageToSpyUsers(String.format(event.getFormat(), user.getDisplayName(), event.getMessage()));
-	}
+                 Bukkit.getScheduler().scheduleSyncDelayedTask(ess, new Runnable()
+                                        {
+                                                @Override
+                                                public void run()
+                                                {
+                                                        EssentialsXMPP.updatePresence();
+                                                }
+                                        });
 
-	@EventHandler(priority = EventPriority.MONITOR)
-	public void onPlayerQuit(final PlayerQuitEvent event)
-	{
-		final User user = ess.getUser(event.getPlayer());
-		sendMessageToSpyUsers("Player " + user.getDisplayName() + " left the game");
-	}
+                sendMessageToSpyUsers("Player " + user.getDisplayName() + " joined the game");
+        }
 
-	private void sendMessageToSpyUsers(final String message)
-	{
-		try
-		{
-			List<String> users = EssentialsXMPP.getInstance().getSpyUsers();
-			synchronized (users)
-			{
-				for (final String address : users)
-				{
-					Bukkit.getScheduler().scheduleSyncDelayedTask(ess, new Runnable()
-					{
-						@Override
-						public void run()
-						{
-							EssentialsXMPP.getInstance().sendMessage(address, message);
-						}
+        @EventHandler(priority = EventPriority.MONITOR)
+        public void onPlayerChat(final AsyncPlayerChatEvent event)
+        {
+                final User user = ess.getUser(event.getPlayer());
+                sendMessageToSpyUsers(String.format(event.getFormat(), user.getDisplayName(), event.getMessage()));
+        }
 
-					});
+        @EventHandler(priority = EventPriority.MONITOR)
+        public void onPlayerQuit(final PlayerQuitEvent event)
+        {
+                final User user = ess.getUser(event.getPlayer());
 
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-			// Ignore exceptions
-		}
-	}
+                 Bukkit.getScheduler().scheduleSyncDelayedTask(ess, new Runnable()
+                                        {
+                                                @Override
+                                                public void run()
+                                                {
+                                                        EssentialsXMPP.updatePresence();
+                                                }
+                                        });
+
+
+                sendMessageToSpyUsers("Player " + user.getDisplayName() + " left the game");
+        }
+
+        private void sendMessageToSpyUsers(final String message)
+        {
+                try
+                {
+                        List<String> users = EssentialsXMPP.getInstance().getSpyUsers();
+                        synchronized (users)
+                        {
+                                for (final String address : users)
+                                {
+                                        Bukkit.getScheduler().scheduleSyncDelayedTask(ess, new Runnable()
+                                        {
+                                                @Override
+                                                public void run()
+                                                {
+                                                        EssentialsXMPP.getInstance().sendMessage(address, message);
+                                                }
+
+                                        });
+
+                                }
+                        }
+                }
+                catch (Exception ex)
+                {
+                        // Ignore exceptions
+                }
+        }
 }

--- a/EssentialsXMPP/src/com/earth2me/essentials/xmpp/XMPPManager.java
+++ b/EssentialsXMPP/src/com/earth2me/essentials/xmpp/XMPPManager.java
@@ -1,5 +1,6 @@
 package com.earth2me.essentials.xmpp;
 
+import com.earth2me.essentials.IEssentials;
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.EssentialsConf;
 import com.earth2me.essentials.IConf;
@@ -12,369 +13,396 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
+import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.Roster.SubscriptionMode;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.util.StringUtils;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
 
 
 public class XMPPManager extends Handler implements MessageListener, ChatManagerListener, IConf
 {
-	private static final Logger LOGGER = Logger.getLogger("Minecraft");
-	private static final SimpleFormatter formatter = new SimpleFormatter();
-	private final transient EssentialsConf config;
-	private transient XMPPConnection connection;
-	private transient ChatManager chatManager;
-	private final transient Map<String, Chat> chats = Collections.synchronizedMap(new HashMap<String, Chat>());
-	private final transient Set<LogRecord> logrecords = Collections.synchronizedSet(new HashSet<LogRecord>());
-	private final transient IEssentialsXMPP parent;
-	private transient List<String> logUsers;
-	private transient Level logLevel;
-	private transient boolean ignoreLagMessages = true;
-	private transient Thread loggerThread;
-	private transient boolean threadrunning = true;
+        private static final Logger LOGGER = Logger.getLogger("Minecraft");
+        private static final SimpleFormatter formatter = new SimpleFormatter();
+        private final transient EssentialsConf config;
+        private transient XMPPConnection connection;
+        private transient ChatManager chatManager;
+        private final transient Map<String, Chat> chats = Collections.synchronizedMap(new HashMap<String, Chat>());
+        private final transient Set<LogRecord> logrecords = Collections.synchronizedSet(new HashSet<LogRecord>());
+        private final transient IEssentialsXMPP parent;
+        private transient List<String> logUsers;
+        private transient Level logLevel;
+        private transient boolean ignoreLagMessages = true;
+        private transient Thread loggerThread;
+        private transient boolean threadrunning = true;
 
-	public XMPPManager(final IEssentialsXMPP parent)
-	{
-		super();
-		this.parent = parent;
-		config = new EssentialsConf(new File(parent.getDataFolder(), "config.yml"));
-		config.setTemplateName("/config.yml", EssentialsXMPP.class);
-		reloadConfig();
-	}
+        public XMPPManager(final IEssentialsXMPP parent)
+        {
+                super();
+                this.parent = parent;
+                config = new EssentialsConf(new File(parent.getDataFolder(), "config.yml"));
+                config.setTemplateName("/config.yml", EssentialsXMPP.class);
+                reloadConfig();
+        }
 
-	public boolean sendMessage(final String address, final String message)
-	{
-		if (address != null && !address.isEmpty())
-		{
-			try
-			{
-				startChat(address);
-				final Chat chat;
-				synchronized (chats)
-				{
-					chat = chats.get(address);
-				}
-				if (chat != null)
-				{
-					if (!connection.isConnected())
-					{
-						disconnect();
-						connect();
-					}
-					chat.sendMessage(FormatUtil.stripFormat(message));
-					return true;
-				}
-			}
-			catch (XMPPException ex)
-			{
-				disableChat(address);
-			}
-		}
-		return false;
-	}
+        public boolean sendMessage(final String address, final String message)
+        {
+                if (address != null && !address.isEmpty())
+                {
+                        try
+                        {
+                                startChat(address);
+                                final Chat chat;
+                                synchronized (chats)
+                                {
+                                        chat = chats.get(address);
+                                }
+                                if (chat != null)
+                                {
+                                        if (!connection.isConnected())
+                                        {
+                                                disconnect();
+                                                connect();
+                                        }
+                                        chat.sendMessage(FormatUtil.stripFormat(message));
+                                        return true;
+                                }
+                        }
+                        catch (XMPPException ex)
+                        {
+                                disableChat(address);
+                        }
+                }
+                return false;
+        }
 
-	@Override
-	public void processMessage(final Chat chat, final Message msg)
-	{
-		// Normally we should log the error message
-		// But we would create a loop if the connection to a log-user fails.
-		if (msg.getType() != Message.Type.error && msg.getBody().length() > 0)
-		{
-			final String message = msg.getBody();
-			switch (message.charAt(0))
-			{
-			case '@':
-				sendPrivateMessage(chat, message);
-				break;
-			case '/':
-				sendCommand(chat, message);
-				break;
-			default:
-				final IUser sender = parent.getUserByAddress(StringUtils.parseBareAddress(chat.getParticipant()));
-				parent.broadcastMessage(sender, "=" + sender.getBase().getDisplayName() + ": " + message, StringUtils.parseBareAddress(chat.getParticipant()));
-			}
-		}
-	}
+        @Override
+        public void processMessage(final Chat chat, final Message msg)
+        {
+                // Normally we should log the error message
+                // But we would create a loop if the connection to a log-user fails.
+                if (msg.getType() != Message.Type.error && msg.getBody().length() > 0)
+                {
+                        final String message = msg.getBody();
+                        switch (message.charAt(0))
+                        {
+                        case '@':
+                                sendPrivateMessage(chat, message);
+                                break;
+                        case '/':
+                                sendCommand(chat, message);
+                                break;
+                        default:
+                                final IUser sender = parent.getUserByAddress(StringUtils.parseBareAddress(chat.getParticipant()));
+                                parent.broadcastMessage(sender, "=" + sender.getBase().getDisplayName() + ": " + message, StringUtils.parseBareAddress(chat.getParticipant()));
+                        }
+                }
+        }
 
-	private boolean connect()
-	{
-		final String server = config.getString("xmpp.server");
-		if (server == null || server.equals("example.com"))
-		{
-			LOGGER.log(Level.WARNING, "config broken for xmpp");
-			return false;
-		}
-		final int port = config.getInt("xmpp.port", 5222);
-		final String serviceName = config.getString("xmpp.servicename", server);
-		final String xmppuser = config.getString("xmpp.user");
-		final String password = config.getString("xmpp.password");
-		final ConnectionConfiguration connConf = new ConnectionConfiguration(server, port, serviceName);
-		final StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.append("Connecting to xmpp server ").append(server).append(":").append(port);
-		stringBuilder.append(" as user ").append(xmppuser).append(".");
-		LOGGER.log(Level.INFO, stringBuilder.toString());
-		connConf.setSASLAuthenticationEnabled(config.getBoolean("xmpp.sasl-enabled", false));
-		connConf.setSendPresence(true);
-		connConf.setReconnectionAllowed(true);
-		connConf.setDebuggerEnabled(config.getBoolean("debug", false));
-		connection = new XMPPConnection(connConf);
-		try
-		{
-			connection.connect();
-			connection.login(xmppuser, password);
-			connection.getRoster().setSubscriptionMode(SubscriptionMode.accept_all);
-			chatManager = connection.getChatManager();
-			chatManager.addChatListener(this);
-			return true;
-		}
-		catch (XMPPException ex)
-		{
-			LOGGER.log(Level.WARNING, "Failed to connect to server: " + server, ex);
-			return false;
-		}
-	}
+        private boolean connect()
+        {
+                final String server = config.getString("xmpp.server");
+                if (server == null || server.equals("example.com"))
+                {
+                        LOGGER.log(Level.WARNING, "config broken for xmpp");
+                        return false;
+                }
+                final int port = config.getInt("xmpp.port", 5222);
+                final String serviceName = config.getString("xmpp.servicename", server);
+                final String xmppuser = config.getString("xmpp.user");
+                final String password = config.getString("xmpp.password");
+                final ConnectionConfiguration connConf = new ConnectionConfiguration(server, port, serviceName);
+                final StringBuilder stringBuilder = new StringBuilder();
+                stringBuilder.append("Connecting to xmpp server ").append(server).append(":").append(port);
+                stringBuilder.append(" as user ").append(xmppuser).append(".");
+                LOGGER.log(Level.INFO, stringBuilder.toString());
+                connConf.setSASLAuthenticationEnabled(config.getBoolean("xmpp.sasl-enabled", false));
+                connConf.setSendPresence(true);
+                connConf.setReconnectionAllowed(true);
+                connConf.setDebuggerEnabled(config.getBoolean("debug", false));
+                connection = new XMPPConnection(connConf);
+                try
+                {
+                        connection.connect();
 
-	public final void disconnect()
-	{
-		if (loggerThread != null)
-		{
-			loggerThread.interrupt();
-		}
-		if (chatManager != null)
-		{
-			chatManager.removeChatListener(this);
-			chatManager = null;
-		}
-		if (connection != null)
-		{
-			connection.disconnect(new Presence(Presence.Type.unavailable));
-		}
+                        connection.login(xmppuser, password, "Essentials-XMPP");
+                        connection.sendPacket(new Presence(Presence.Type.available, "No one online.", 2, Presence.Mode.available));
 
-	}
+                        connection.getRoster().setSubscriptionMode(SubscriptionMode.accept_all);
+                        chatManager = connection.getChatManager();
+                        chatManager.addChatListener(this);
+                        return true;
+                }
+                catch (XMPPException ex)
+                {
+                        LOGGER.log(Level.WARNING, "Failed to connect to server: " + server, ex);
+                        return false;
+                }
+        }
 
-	@Override
-	public void chatCreated(final Chat chat, final boolean createdLocally)
-	{
-		if (!createdLocally)
-		{
-			chat.addMessageListener(this);
-			final Chat old = chats.put(StringUtils.parseBareAddress(chat.getParticipant()), chat);
-			if (old != null)
-			{
-				old.removeMessageListener(this);
-			}
-		}
-	}
+        public final void disconnect()
+        {
+                if (loggerThread != null)
+                {
+                        loggerThread.interrupt();
+                }
+                if (chatManager != null)
+                {
+                        chatManager.removeChatListener(this);
+                        chatManager = null;
+                }
+                if (connection != null)
+                {
+                        connection.disconnect(new Presence(Presence.Type.unavailable));
+                }
 
-	@Override
-	public final void reloadConfig()
-	{
-		LOGGER.removeHandler(this);
-		config.load();
-		synchronized (chats)
-		{
-			disconnect();
-			chats.clear();
-			if (!connect())
-			{
-				return;
-			}
-			startLoggerThread();
-		}
-		if (config.getBoolean("log-enabled", false))
-		{
-			LOGGER.addHandler(this);
-			logUsers = config.getStringList("log-users");
-			final String level = config.getString("log-level", "info");
-			try
-			{
-				logLevel = Level.parse(level.toUpperCase(Locale.ENGLISH));
-			}
-			catch (IllegalArgumentException e)
-			{
-				logLevel = Level.INFO;
-			}
-			ignoreLagMessages = config.getBoolean("ignore-lag-messages", true);
-		}
-	}
+        }
 
-	@Override
-	public void publish(final LogRecord logRecord)
-	{
-		try
-		{
-			if (ignoreLagMessages && logRecord.getMessage().equals("Can't keep up! Did the system time change, or is the server overloaded?"))
-			{
-				return;
-			}
-			if (logRecord.getLevel().intValue() >= logLevel.intValue())
-			{
-				synchronized (logrecords)
-				{
-					logrecords.add(logRecord);
-				}
-			}
-		}
-		catch (Exception e)
-		{
-			// Ignore all exceptions
-			// Otherwise we create a loop.
-		}
-	}
+        public final void updatePresence()
+        {
+                final int usercount;
+                final StringBuilder stringBuilder = new StringBuilder();
 
-	@Override
-	public void flush()
-	{
-		// Ignore this
-	}
+                usercount = parent.getServer().getOnlinePlayers().length;
 
-	@Override
-	public void close() throws SecurityException
-	{
-		// Ignore this
-	}
+                if (usercount == 0) {
+                        final String presenceMsg = "No one online.";
+                        connection.sendPacket(new Presence(Presence.Type.available, presenceMsg, 2, Presence.Mode.available));
+                }
+                if (usercount == 1) {
+                        final String presenceMsg = "1 player online.";
+                        connection.sendPacket(new Presence(Presence.Type.available, presenceMsg, 2, Presence.Mode.dnd));
+                }
+                if (usercount > 1) {
+                        stringBuilder.append(usercount).append(" players online.");
+                        connection.sendPacket(new Presence(Presence.Type.available, stringBuilder.toString(), 2, Presence.Mode.dnd));
+                }
+        }
 
-	private void startLoggerThread()
-	{
-		loggerThread = new Thread(new Runnable()
-		{
-			@Override
-			public void run()
-			{
-				final Set<LogRecord> copy = new HashSet<LogRecord>();
-				final Set<String> failedUsers = new HashSet<String>();
-				while (threadrunning)
-				{
-					synchronized (logrecords)
-					{
-						if (!logrecords.isEmpty())
-						{
-							copy.addAll(logrecords);
-							logrecords.clear();
-						}
-					}
-					if (!copy.isEmpty())
-					{
-						for (String user : logUsers)
-						{
-							try
-							{
-								XMPPManager.this.startChat(user);
-								for (LogRecord logRecord : copy)
-								{
-									final String message = formatter.format(logRecord);
-									if (!XMPPManager.this.sendMessage(user, FormatUtil.stripLogColorFormat(message)))
-									{
-										failedUsers.add(user);
-										break;
-									}
+        @Override
+        public void chatCreated(final Chat chat, final boolean createdLocally)
+        {
+                if (!createdLocally)
+                {
+                        chat.addMessageListener(this);
+                        final Chat old = chats.put(StringUtils.parseBareAddress(chat.getParticipant()), chat);
+                        if (old != null)
+                        {
+                                old.removeMessageListener(this);
+                        }
+                }
+        }
 
-								}
-							}
-							catch (XMPPException ex)
-							{
-								failedUsers.add(user);
-								LOGGER.removeHandler(XMPPManager.this);
-								LOGGER.log(Level.SEVERE, "Failed to deliver log message! Disabling logging to XMPP.", ex);
-							}
-						}
-						logUsers.removeAll(failedUsers);
-						if (logUsers.isEmpty())
-						{
-							LOGGER.removeHandler(XMPPManager.this);
-							threadrunning = false;
-						}
-						copy.clear();
-					}
-					try
-					{
-						Thread.sleep(2000);
-					}
-					catch (InterruptedException ex)
-					{
-						threadrunning = false;
-					}
-				}
-				LOGGER.removeHandler(XMPPManager.this);
-			}
-		});
-		loggerThread.start();
-	}
+        @Override
+        public final void reloadConfig()
+        {
+                LOGGER.removeHandler(this);
+                config.load();
+                synchronized (chats)
+                {
+                        disconnect();
+                        chats.clear();
+                        if (!connect())
+                        {
+                                return;
+                        }
+                        startLoggerThread();
+                }
+                if (config.getBoolean("log-enabled", false))
+                {
+                        LOGGER.addHandler(this);
+                        logUsers = config.getStringList("log-users");
+                        final String level = config.getString("log-level", "info");
+                        try
+                        {
+                                logLevel = Level.parse(level.toUpperCase(Locale.ENGLISH));
+                        }
+                        catch (IllegalArgumentException e)
+                        {
+                                logLevel = Level.INFO;
+                        }
+                        ignoreLagMessages = config.getBoolean("ignore-lag-messages", true);
+                }
+        }
 
-	private void startChat(final String address) throws XMPPException
-	{
-		if (chatManager == null)
-		{
-			return;
-		}
-		synchronized (chats)
-		{
-			if (!chats.containsKey(address))
-			{
-				final Chat chat = chatManager.createChat(address, this);
-				if (chat == null)
-				{
-					throw new XMPPException("Could not start Chat with " + address);
-				}
-				chats.put(address, chat);
-			}
-		}
-	}
+        @Override
+        public void publish(final LogRecord logRecord)
+        {
+                try
+                {
+                        if (ignoreLagMessages && logRecord.getMessage().equals("Can't keep up! Did the system time change, or is the server overloaded?"))
+                        {
+                                return;
+                        }
+                        if (logRecord.getLevel().intValue() >= logLevel.intValue())
+                        {
+                                synchronized (logrecords)
+                                {
+                                        logrecords.add(logRecord);
+                                }
+                        }
+                }
+                catch (Exception e)
+                {
+                        // Ignore all exceptions
+                        // Otherwise we create a loop.
+                }
+        }
 
-	private void sendPrivateMessage(final Chat chat, final String message)
-	{
-		final String[] parts = message.split(" ", 2);
-		if (parts.length == 2)
-		{
-			final List<Player> matches = parent.getServer().matchPlayer(parts[0].substring(1));
+        @Override
+        public void flush()
+        {
+                // Ignore this
+        }
 
-			if (matches.isEmpty())
-			{
-				try
-				{
-					chat.sendMessage("User " + parts[0] + " not found");
-				}
-				catch (XMPPException ex)
-				{
-					LOGGER.log(Level.WARNING, "Failed to send xmpp message.", ex);
-				}
-			}
-			else
-			{
-				final String from = "[" + parent.getUserByAddress(StringUtils.parseBareAddress(chat.getParticipant())) + ">";
-				for (Player p : matches)
-				{
-					p.sendMessage(from + p.getDisplayName() + "]  " + message);
-				}
-			}
-		}
-	}
+        @Override
+        public void close() throws SecurityException
+        {
+                // Ignore this
+        }
 
-	private void sendCommand(final Chat chat, final String message)
-	{
-		if (config.getStringList("op-users").contains(StringUtils.parseBareAddress(chat.getParticipant())))
-		{
-			try
-			{
-				parent.getServer().dispatchCommand(Console.getCommandSender(parent.getServer()), message.substring(1));
-			}
-			catch (Exception ex)
-			{
-				LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
-			}
-		}
-	}
+        private void startLoggerThread()
+        {
+                loggerThread = new Thread(new Runnable()
+                {
+                        @Override
+                        public void run()
+                        {
+                                final Set<LogRecord> copy = new HashSet<LogRecord>();
+                                final Set<String> failedUsers = new HashSet<String>();
+                                while (threadrunning)
+                                {
+                                        synchronized (logrecords)
+                                        {
+                                                if (!logrecords.isEmpty())
+                                                {
+                                                        copy.addAll(logrecords);
+                                                        logrecords.clear();
+                                                }
+                                        }
+                                        if (!copy.isEmpty())
+                                        {
+                                                for (String user : logUsers)
+                                                {
+                                                        try
+                                                        {
+                                                                XMPPManager.this.startChat(user);
+                                                                for (LogRecord logRecord : copy)
+                                                                {
+                                                                        final String message = formatter.format(logRecord);
+                                                                        if (!XMPPManager.this.sendMessage(user, FormatUtil.stripLogColorFormat(message)))
+                                                                        {
+                                                                                failedUsers.add(user);
+                                                                                break;
+                                                                        }
 
-	private void disableChat(final String address)
-	{
-		final Chat chat = chats.get(address);
-		if (chat != null)
-		{
-			chat.removeMessageListener(this);
-			chats.remove(address);
-		}
-	}
+                                                                }
+                                                        }
+                                                        catch (XMPPException ex)
+                                                        {
+                                                                failedUsers.add(user);
+                                                                LOGGER.removeHandler(XMPPManager.this);
+                                                                LOGGER.log(Level.SEVERE, "Failed to deliver log message! Disabling logging to XMPP.", ex);
+                                                        }
+                                                }
+                                                logUsers.removeAll(failedUsers);
+                                                if (logUsers.isEmpty())
+                                                {
+                                                        LOGGER.removeHandler(XMPPManager.this);
+                                                        threadrunning = false;
+                                                }
+                                                copy.clear();
+                                        }
+                                        try
+                                        {
+                                                Thread.sleep(2000);
+                                        }
+                                        catch (InterruptedException ex)
+                                        {
+                                                threadrunning = false;
+                                        }
+                                }
+                                LOGGER.removeHandler(XMPPManager.this);
+                        }
+                });
+                loggerThread.start();
+        }
+
+        private void startChat(final String address) throws XMPPException
+        {
+                if (chatManager == null)
+                {
+                        return;
+                }
+                synchronized (chats)
+                {
+                        if (!chats.containsKey(address))
+                        {
+                                final Chat chat = chatManager.createChat(address, this);
+                                if (chat == null)
+                                {
+                                        throw new XMPPException("Could not start Chat with " + address);
+                                }
+                                chats.put(address, chat);
+                        }
+                }
+        }
+
+        private void sendPrivateMessage(final Chat chat, final String message)
+        {
+                final String[] parts = message.split(" ", 2);
+                if (parts.length == 2)
+                {
+                        final List<Player> matches = parent.getServer().matchPlayer(parts[0].substring(1));
+
+                        if (matches.isEmpty())
+                        {
+                                try
+                                {
+                                        chat.sendMessage("User " + parts[0] + " not found");
+                                }
+                                catch (XMPPException ex)
+                                {
+                                        LOGGER.log(Level.WARNING, "Failed to send xmpp message.", ex);
+                                }
+                        }
+                        else
+                        {
+                                final String from = "[" + parent.getUserByAddress(StringUtils.parseBareAddress(chat.getParticipant())) + ">";
+                                for (Player p : matches)
+                                {
+                                        p.sendMessage(from + p.getDisplayName() + "]  " + message);
+                                }
+                        }
+                }
+        }
+
+        private void sendCommand(final Chat chat, final String message)
+        {
+                if (config.getStringList("op-users").contains(StringUtils.parseBareAddress(chat.getParticipant())))
+                {
+                        try
+                        {
+                                parent.getServer().dispatchCommand(Console.getCommandSender(parent.getServer()), message.substring(1));
+                        }
+                        catch (Exception ex)
+                        {
+                                LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
+                        }
+                }
+        }
+
+        private void disableChat(final String address)
+        {
+                final Chat chat = chats.get(address);
+                if (chat != null)
+                {
+                        chat.removeMessageListener(this);
+                        chats.remove(address);
+                }
+        }
 }


### PR DESCRIPTION
The attached pull includes support for logging into an XMPP server and providing game status information, including how many players are online.  As more then 1 user connects to the server, the presence status will change red to indicate the server is busy with descriptive information and user online count.  This includes support for task scheduling of the presence update as players log on/log off the server to provide minimal impact or delay to gameplay.

![xmppfun2](https://f.cloud.github.com/assets/5677937/1322714/2972fe52-3445-11e3-90a8-05bbba08d780.PNG)
