### PR TITLE
Add IEssentialsSpawn API class for Essentials Spawn

### DIFF
--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawn.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawn.java
@@ -5,6 +5,7 @@ import net.ess3.api.IEssentials;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Event;
@@ -17,7 +18,7 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 
-public class EssentialsSpawn extends JavaPlugin
+public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn
 {
 	private static final Logger LOGGER = Bukkit.getLogger();
 	private transient IEssentials ess;
@@ -69,5 +70,25 @@ public class EssentialsSpawn extends JavaPlugin
 	public boolean onCommand(final CommandSender sender, final Command command, final String commandLabel, final String[] args)
 	{
 		return ess.onCommandEssentials(sender, command, commandLabel, args, EssentialsSpawn.class.getClassLoader(), "com.earth2me.essentials.spawn.Command", "essentials.", spawns);
+	}
+
+	@Override
+	public void setSpawn(Location loc, String group)
+	{
+		if (group == null)
+		{
+			throw new IllegalArgumentException("Null group");
+		}
+		spawns.setSpawn(loc, group);
+	}
+
+	@Override
+	public Location getSpawn(String group)
+	{
+		if (group == null)
+		{
+			throw new IllegalArgumentException("Null group");
+		}
+		return spawns.getSpawn(group);
 	}
 }

--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/IEssentialsSpawn.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/IEssentialsSpawn.java
@@ -9,6 +9,7 @@ public interface IEssentialsSpawn extends Plugin
 
 	/**
 	 * Sets the spawn for a given group to a given location.
+	 *
 	 * @param loc The location to set the spawn to
 	 * @param group The group to set the spawn of, or 'default' for the default spawn
 	 * @throws IllegalArgumentException If group is null
@@ -17,6 +18,7 @@ public interface IEssentialsSpawn extends Plugin
 
 	/**
 	 * Gets the spawn location for a given group.
+	 *
 	 * @param group The group to get the spawn of, or 'default' for the default spawn
 	 * @return The spawn location set for the given group
 	 * @throws IllegalArgumentException If group is null

--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/IEssentialsSpawn.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/IEssentialsSpawn.java
@@ -1,0 +1,25 @@
+package com.earth2me.essentials.spawn;
+
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+
+public interface IEssentialsSpawn extends Plugin
+{
+
+	/**
+	 * Sets the spawn for a given group to a given location.
+	 * @param loc The location to set the spawn to
+	 * @param group The group to set the spawn of, or 'default' for the default spawn
+	 * @throws IllegalArgumentException If group is null
+	 */
+	public void setSpawn(Location loc, String group);
+
+	/**
+	 * Gets the spawn location for a given group.
+	 * @param group The group to get the spawn of, or 'default' for the default spawn
+	 * @return The spawn location set for the given group
+	 * @throws IllegalArgumentException If group is null
+	 */
+	public Location getSpawn(String group);
+}


### PR DESCRIPTION
This adds an IEssentialsSpawn class and implements it in EssentialsSpawn.

The IEssentialsSpawn class has two methods, getSpawn(String) and setSpawn(String, Location).

Currently, other plugins have no way to get or set spawns for EssentialsSpawn. This commit adds a bare minimum API that allows that.
