### PR TITLE
[Feature] Add ability to specify /sell and /worth multiplier per world.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -43,6 +43,10 @@ public interface ISettings extends IConf
 	double getHealCooldown();
 
 	Set<String> getSocialSpyCommands();
+        
+	Object getWorldPriceMultiplier(String name);
+
+	ConfigurationSection getWorldPriceMultipliers();        
 
 	Map<String, Object> getKit(String name);
 

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -289,8 +289,45 @@ public class Settings implements net.ess3.api.ISettings
 	{
 		return config.getDouble("heal-cooldown", 0);
 	}
-	private ConfigurationSection kits;
+        
+    private ConfigurationSection worldPriceMultipliers;
+        
+	private ConfigurationSection _getWorldPriceMultipliers()
+	{            
+		if (config.isConfigurationSection("world-price-multipliers"))
+		{
+			final ConfigurationSection section = config.getConfigurationSection("world-price-multipliers");
+			final ConfigurationSection newSection = new MemoryConfiguration();
+			for (String worldPriceMultiplierItem : section.getKeys(false))
+			{
+				newSection.set(worldPriceMultiplierItem.toLowerCase(Locale.ENGLISH), section.get(worldPriceMultiplierItem));
+            }
 
+			return newSection;
+		}
+		return null;
+	}
+
+	@Override
+	public ConfigurationSection getWorldPriceMultipliers()
+	{
+		return worldPriceMultipliers;
+	}
+        
+	@Override
+	public Object getWorldPriceMultiplier(String name)
+	{
+		name = name.replace('.', '_').replace('/', '_');
+		if (getWorldPriceMultipliers() != null)
+		{
+			final ConfigurationSection worldPriceMultipliers = getWorldPriceMultipliers();
+            return worldPriceMultipliers.get(name);
+		}
+		return null;
+	}        
+        
+	private ConfigurationSection kits;
+        
 	private ConfigurationSection _getKits()
 	{
 		if (config.isConfigurationSection("kits"))
@@ -496,6 +533,7 @@ public class Settings implements net.ess3.api.ISettings
 		itemSpawnBl = _getItemSpawnBlacklist();
 		loginAttackDelay = _getLoginAttackDelay();
 		signUsePerSecond = _getSignUsePerSecond();
+        worldPriceMultipliers = _getWorldPriceMultipliers();
 		kits = _getKits();
 		chatFormats.clear();
 		changeDisplayName = _changeDisplayName();

--- a/Essentials/src/com/earth2me/essentials/Worth.java
+++ b/Essentials/src/com/earth2me/essentials/Worth.java
@@ -22,7 +22,7 @@ public class Worth implements IConf
 		config.load();
 	}
 
-	public BigDecimal getPrice(ItemStack itemStack)
+	public BigDecimal getPrice(IEssentials ess, User user, ItemStack itemStack)
 	{
 		String itemname = itemStack.getType().toString().toLowerCase(Locale.ENGLISH).replace("_", "");
 		BigDecimal result;
@@ -55,8 +55,23 @@ public class Worth implements IConf
 		{
 			return null;
 		}
+
+		// Get the world price multiplier (if any)
+		Object priceMultiplerObject = ess.getSettings().getWorldPriceMultiplier(user.getWorld().getName());
+		BigDecimal priceMultiplier;
+		if(priceMultiplerObject != null)
+		{
+			priceMultiplier = EssentialsConf.toBigDecimal(priceMultiplerObject.toString(),null);
+		}
+		else                
+		{
+			priceMultiplier = EssentialsConf.toBigDecimal("1.0",null);
+		}
+
+		result = result.multiply(priceMultiplier);
+                
 		return result;
-	}
+        }
 
 	public int getAmount(IEssentials ess, User user, ItemStack is, String[] args, boolean isBulkSell) throws Exception
 	{

--- a/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
@@ -75,7 +75,7 @@ public class Commandsell extends EssentialsCommand
 	private BigDecimal sellItem(User user, ItemStack is, String[] args, boolean isBulkSell) throws Exception
 	{
 		int amount = ess.getWorth().getAmount(ess, user, is, args, isBulkSell);
-		BigDecimal worth = ess.getWorth().getPrice(is);
+		BigDecimal worth = ess.getWorth().getPrice(ess, user, is);
 
 		if (worth == null)
 		{

--- a/Essentials/src/com/earth2me/essentials/commands/Commandworth.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandworth.java
@@ -106,7 +106,7 @@ public class Commandworth extends EssentialsCommand
 			amount = ess.getWorth().getAmount(ess, user, is, args, true);
 		}
 
-		BigDecimal worth = ess.getWorth().getPrice(is);
+		BigDecimal worth = ess.getWorth().getPrice(ess, user, is);
 
 		if (worth == null)
 		{

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -468,6 +468,15 @@ min-money: -10000
 # Enable this to log all interactions with trade/buy/sell signs and sell command.
 economy-log-enabled: false
 
+# Add a /sell and /worth multiplier to each world
+# Default value is 1.0
+# Typically used with plugins that will create separate inventories per world.
+# Uncomment world-price-multipliers and list the worlds you would like with different multipliers.
+#world-price-multipliers:
+#  world: 1
+#  world_normal: 1.5
+#  world_hard: 4
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                   EssentialsHelp                     | #


### PR DESCRIPTION
Summary of changes:

1) Added new config section called world-price-multipliers
2) Modified Worth.getPrice to apply any world multipliers noted in 1

Tested the following scenarios:

1) Completely missing the world-price-multipliers config section (default 1.0)
2) world-price-multipliers section exists but current world in was missing (default 1.0)
3) /sell and /worth in various worlds with different multipliers.

Sample screenshot: http://i.imgur.com/xAIuMuH.png
