### PR TITLE
[Feature] Add the ability to disable safe teleport.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -84,6 +84,8 @@ public interface ISettings extends IConf
 
 	double getTeleportDelay();
 
+	boolean isSafeTeleportEnabled();
+
 	boolean hidePermissionlessHelp();
 
 	boolean isCommandDisabled(final IEssentialsCommand cmd);

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -279,6 +279,12 @@ public class Settings implements net.ess3.api.ISettings
 	}
 
 	@Override
+	public boolean isSafeTeleportEnabled()
+	{
+		return config.getBoolean("teleport-safely", true);
+	}
+
+	@Override
 	public double getTeleportCooldown()
 	{
 		return config.getDouble("teleport-cooldown", 0);

--- a/Essentials/src/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/com/earth2me/essentials/Teleport.java
@@ -96,7 +96,14 @@ public class Teleport implements net.ess3.api.ITeleport
 	{
 		cancel(false);
 		teleportee.setLastLocation();
-		teleportee.getBase().teleport(LocationUtil.getSafeDestination(teleportee, target.getLocation()), cause);
+		if (ess.getSettings().isSafeTeleportEnabled())
+		{
+			teleportee.getBase().teleport(LocationUtil.getSafeDestination(teleportee, target.getLocation()), cause);
+		}
+		else
+		{
+			teleportee.getBase().teleport(target.getLocation(), cause);
+		}
 	}
 
 	//The teleportPlayer function is used when you want to normally teleportPlayer someone to a location or player.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -41,6 +41,9 @@ change-displayname: true
 # Do not edit this setting unless you know what you are doing!
 #add-prefix-suffix: false
 
+# When a player is teleported are they to be placed in a safe possition to prevent damage.
+teleport-safely: true
+
 # The delay, in seconds, required between /home, /tp, etc.
 teleport-cooldown: 0
 


### PR DESCRIPTION
Allow server administrators to choose if they wish to have safe teleport enabled or disabled.
Safe teleport is enabled by default so not to interfere with current set-ups and configurations.
