### PR TITLE
Add Java8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6


### PR DESCRIPTION
Add Java8 Support (Travis)
Oracle JDK 8 ("Early Access" release)
