### PR TITLE
Groupmanager

### DIFF
--- a/EssentialsGroupManager/src/Changelog.txt
+++ b/EssentialsGroupManager/src/Changelog.txt
@@ -220,3 +220,4 @@ v 2.0:
 	- Warn when adding a node where an exception already exist.
 	- Only prevent adding nodes with '/manuaddp' and '/mangaddp' if they are exact matches (not wildcards).
 	- Store worldSelection indexed on the senders name rather than the object (fixes commandblocks using manselect).
+	- Check subgroup permissions with an equal priority so no one subgroup is higher ranked than another.

--- a/EssentialsGroupManager/src/Changelog.txt
+++ b/EssentialsGroupManager/src/Changelog.txt
@@ -221,3 +221,4 @@ v 2.0:
 	- Only prevent adding nodes with '/manuaddp' and '/mangaddp' if they are exact matches (not wildcards).
 	- Store worldSelection indexed on the senders name rather than the object (fixes commandblocks using manselect).
 	- Check subgroup permissions with an equal priority so no one subgroup is higher ranked than another.
+	- add recursive permission adding/deleting

--- a/EssentialsGroupManager/src/Changelog.txt
+++ b/EssentialsGroupManager/src/Changelog.txt
@@ -222,3 +222,4 @@ v 2.0:
 	- Store worldSelection indexed on the senders name rather than the object (fixes commandblocks using manselect).
 	- Check subgroup permissions with an equal priority so no one subgroup is higher ranked than another.
 	- add recursive permission adding/deleting
+	- Prevent adding sub groups for ranks the granting player doesn't have access to.

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
@@ -38,8 +38,6 @@ import org.bukkit.block.Block;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.command.RemoteConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.ServicePriority;

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
@@ -2107,13 +2107,11 @@ public class GroupManager extends JavaPlugin {
 			{
 				sender.sendMessage(ChatColor.RED + "The " + type + " already has an exception for this node.");
 				sender.sendMessage(ChatColor.RED + "Node: " + oldPerm.accessLevel);
-				return false;
 			}
 			else if (oldPerm.resultType.equals(PermissionCheckResult.Type.NEGATION))
 			{
 				sender.sendMessage(ChatColor.RED + "The " + type + " already has a matching negated node.");
 				sender.sendMessage(ChatColor.RED + "Node: " + oldPerm.accessLevel);
-				return false;
 			}
 			else if (oldPerm.resultType.equals(PermissionCheckResult.Type.FOUND))
 			{

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
@@ -738,11 +738,7 @@ public class GroupManager extends JavaPlugin {
 				
 				for (int i = 1; i < args.length; i++)
 				{
-					auxString = args[i];
-					if (auxString.startsWith("'") && auxString.endsWith("'"))
-					{
-						auxString = auxString.substring(1, auxString.length() - 1);
-					}
+					auxString = args[i].replace("'", "");
 				
 					permissionResult = permissionHandler.checkFullUserPermission(senderUser, auxString);
 					if (!isConsole && !isOpOverride && (permissionResult.resultType.equals(PermissionCheckResult.Type.NOTFOUND) || permissionResult.resultType.equals(PermissionCheckResult.Type.NEGATION))) {
@@ -791,11 +787,7 @@ public class GroupManager extends JavaPlugin {
 				
 				for (int i = 1; i < args.length; i++)
 				{
-					auxString = args[i];
-					if (auxString.startsWith("'") && auxString.endsWith("'"))
-					{
-						auxString = auxString.substring(1, auxString.length() - 1);
-					}
+					auxString = args[i].replace("'", "");
 				
 					if (!isConsole && !isOpOverride && (senderGroup != null ? permissionHandler.inGroup(auxUser.getName(), senderGroup.getName()) : false)) {
 						sender.sendMessage(ChatColor.RED + "You can't modify a player with same group as you, or higher.");
@@ -950,11 +942,7 @@ public class GroupManager extends JavaPlugin {
 					return true;
 				}
 				
-				auxString = args[1];
-				if (auxString.startsWith("'") && auxString.endsWith("'"))
-				{
-					auxString = auxString.substring(1, auxString.length() - 1);
-				}
+				auxString = args[1].replace("'", "");
 
 				if ((validateOnlinePlayer) && ((match = validatePlayer(args[0], sender)) == null)) {
 					return false;
@@ -1019,11 +1007,7 @@ public class GroupManager extends JavaPlugin {
 				
 				for (int i = 1; i < args.length; i++)
 				{
-					auxString = args[i];
-					if (auxString.startsWith("'") && auxString.endsWith("'"))
-					{
-						auxString = auxString.substring(1, auxString.length() - 1);
-					}
+					auxString = args[i].replace("'", "");
 				
 					// Validating your permissions
 					permissionResult = permissionHandler.checkFullUserPermission(senderUser, auxString);
@@ -1065,11 +1049,7 @@ public class GroupManager extends JavaPlugin {
 				}
 				for (int i = 1; i < args.length; i++)
 				{
-					auxString = args[i];
-					if (auxString.startsWith("'") && auxString.endsWith("'"))
-					{
-						auxString = auxString.substring(1, auxString.length() - 1);
-					}
+					auxString = args[i].replace("'", "");
 				
 					// Validating your permissions
 					permissionResult = permissionHandler.checkFullUserPermission(senderUser, auxString);
@@ -1333,10 +1313,7 @@ public class GroupManager extends JavaPlugin {
 						auxString += " ";
 					}
 				}
-				if (auxString.startsWith("'") && auxString.endsWith("'"))
-				{
-					auxString = auxString.substring(1, auxString.length() - 1);
-				}
+				auxString = auxString.replace("'", "");
 				auxUser.getVariables().addVar(args[1], Variables.parseVariableValue(auxString));
 				sender.sendMessage(ChatColor.YELLOW + "Variable " + ChatColor.GOLD + args[1] + ChatColor.YELLOW + ":'" + ChatColor.GREEN + auxString + ChatColor.YELLOW + "' added to the user " + auxUser.getName());
 
@@ -1485,10 +1462,8 @@ public class GroupManager extends JavaPlugin {
 						auxString += " ";
 					}
 				}
-				if (auxString.startsWith("'") && auxString.endsWith("'"))
-				{
-					auxString = auxString.substring(1, auxString.length() - 1);
-				}
+				
+				auxString = auxString.replace("'", "");
 				auxGroup.getVariables().addVar(args[1], Variables.parseVariableValue(auxString));
 				sender.sendMessage(ChatColor.YELLOW + "Variable " + ChatColor.GOLD + args[1] + ChatColor.YELLOW + ":'" + ChatColor.GREEN + auxString + ChatColor.YELLOW + "' added to the group " + auxGroup.getName());
 

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
@@ -2072,7 +2072,7 @@ public class GroupManager extends JavaPlugin {
 	}
 	
 	/**
-	 * Checks if a permission exists and of a lower priority.
+	 * Checks if a permission exists and of a lower or same priority.
 	 */
 	private boolean checkPermissionExists(CommandSender sender, String newPerm, PermissionCheckResult oldPerm, String type) {
 		

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
@@ -2107,13 +2107,13 @@ public class GroupManager extends JavaPlugin {
 			{
 				sender.sendMessage(ChatColor.RED + "The " + type + " already has an exception for this node.");
 				sender.sendMessage(ChatColor.RED + "Node: " + oldPerm.accessLevel);
-				return true;
+				return false;
 			}
 			else if (oldPerm.resultType.equals(PermissionCheckResult.Type.NEGATION))
 			{
 				sender.sendMessage(ChatColor.RED + "The " + type + " already has a matching negated node.");
 				sender.sendMessage(ChatColor.RED + "Node: " + oldPerm.accessLevel);
-				return true;
+				return false;
 			}
 			else if (oldPerm.resultType.equals(PermissionCheckResult.Type.FOUND))
 			{

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
@@ -611,6 +611,14 @@ public class GroupManager extends JavaPlugin {
 					sender.sendMessage(ChatColor.RED + "You can't modify a player with same permissions as you, or higher.");
 					return true;
 				}
+				if (!isConsole && !isOpOverride && (permissionHandler.hasGroupInInheritance(auxGroup, senderGroup.getName()))) {
+					sender.sendMessage(ChatColor.RED + "The sub-group can't be the same as yours, or higher.");
+					return true;
+				}
+				if (!isConsole && !isOpOverride && (!permissionHandler.inGroup(senderUser.getName(), auxUser.getGroupName()) || !permissionHandler.inGroup(senderUser.getName(), auxGroup.getName()))) {
+					sender.sendMessage(ChatColor.RED + "You can't modify a player involving a group that you don't inherit.");
+					return true;
+				}
 				// Seems OK
 				if (auxUser.addSubGroup(auxGroup))
 					sender.sendMessage(ChatColor.YELLOW + "You added subgroup '" + auxGroup.getName() + "' to player '" + auxUser.getName() + "'.");

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/GroupManager.java
@@ -993,7 +993,7 @@ public class GroupManager extends JavaPlugin {
 				}
 				// Validating arguments
 				if (args.length < 2) {
-					sender.sendMessage(ChatColor.RED + "Review your arguments count! (/mangaaddp <group> <permission> [permission2] [permission3]...)");
+					sender.sendMessage(ChatColor.RED + "Review your arguments count! (/mangaddp <group> <permission> [permission2] [permission3]...)");
 					return true;
 				}
 				

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/data/DataUnit.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/data/DataUnit.java
@@ -167,6 +167,7 @@ public abstract class DataUnit {
 	 * @return a copy of the permission list
 	 */
 	public List<String> getPermissionList() {
+		sortPermissions();
 		return permissions;
 	}
 

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/dataholder/worlds/WorldsHolder.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/dataholder/worlds/WorldsHolder.java
@@ -187,7 +187,7 @@ public class WorldsHolder {
 					// These worlds fully mirror their parent
 					for (Object o : mirrorList) {
 						String world = o.toString().toLowerCase();
-						if (world != serverDefaultWorldName) {
+						if (!world.equalsIgnoreCase(serverDefaultWorldName)) {
 							try {
 								mirrorsGroup.remove(world);
 								mirrorsUser.remove(world);
@@ -207,7 +207,7 @@ public class WorldsHolder {
 
 					for (Object key : subSection.keySet()) {
 
-						if (((String)key).toLowerCase() != serverDefaultWorldName) {
+						if (!((String)key).equalsIgnoreCase(serverDefaultWorldName)) {
 
 							if (subSection.get(key) instanceof ArrayList) {
 								ArrayList mirrorList = (ArrayList) subSection.get(key);

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/permissions/AnjoPermissionsHandler.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/permissions/AnjoPermissionsHandler.java
@@ -849,13 +849,26 @@ public class AnjoPermissionsHandler extends PermissionsReaderInterface {
 		// SUBGROUPS CHECK
 		for (Group subGroup : user.subGroupListCopy()) {
 			PermissionCheckResult resultSubGroup = checkGroupPermissionWithInheritance(subGroup, targetPermission);
+			
+			
 			if (resultSubGroup.resultType != PermissionCheckResult.Type.NOTFOUND) {
-				resultSubGroup.accessLevel = targetPermission;
-				return resultSubGroup;
+				
+				if ((resultSubGroup.resultType == PermissionCheckResult.Type.FOUND) && (result.resultType != PermissionCheckResult.Type.NEGATION)) {
+					resultSubGroup.accessLevel = targetPermission;
+					result = resultSubGroup;
+				} else if (resultSubGroup.resultType == PermissionCheckResult.Type.EXCEPTION) {
+					resultSubGroup.accessLevel = targetPermission;
+					return resultSubGroup;
+				} else if (resultSubGroup.resultType == PermissionCheckResult.Type.NEGATION) {
+					resultSubGroup.accessLevel = targetPermission;
+					result = resultSubGroup;
+				}
+				
 			}
 		}
 
 		// THEN IT RETURNS A NOT FOUND
+		// OR THE RESULT OF THE SUBGROUP SEARCH.
 		return result;
 	}
 

--- a/EssentialsGroupManager/src/org/anjocaido/groupmanager/permissions/AnjoPermissionsHandler.java
+++ b/EssentialsGroupManager/src/org/anjocaido/groupmanager/permissions/AnjoPermissionsHandler.java
@@ -151,6 +151,10 @@ public class AnjoPermissionsHandler extends PermissionsReaderInterface {
 					// or It's a negated perm where a normal perm doesn't exists (don't allow inheritance to negate higher perms)
 					if ((!negated && !playerPermArray.contains(perm) && !wildcardNegation(playerPermArray, perm)) || (negated && !playerPermArray.contains(perm.substring(1)) && !wildcardNegation(playerPermArray, perm.substring(1))))
 						playerPermArray.add(perm);
+					
+					if (perm.startsWith("+") && wildcardNegation(groupPermArray, perm.substring(1))) {
+						playerPermArray.add(perm.substring(1));
+					}
 				}
 			}
 

--- a/EssentialsGroupManager/src/plugin.yml
+++ b/EssentialsGroupManager/src/plugin.yml
@@ -34,11 +34,11 @@ commands:
     permissions: groupmanager.mangdel
   manuaddp:
     description: Add permissions directly to the player.
-    usage: /<command> <player> <permissions>
+    usage: /<command> <player> <permission> [permission2] [permission3]..
     permissions: groupmanager.manuaddp
   manudelp:
     description: Removes permissions directly from the player.
-    usage: /<command> <player> <permissions>
+    usage: /<command> <player> <permission> [permission2] [permission3]..
     permissions: groupmanager.manudelp
   manuclearp:
     description: Removes all permissions of a player.
@@ -54,11 +54,11 @@ commands:
     permissions: groupmanager.manucheckp
   mangaddp:
     description: Add permissions to a group.
-    usage: /<command> <group> <permissions>
+    usage: /<command> <group> <permission> [permission2] [permission3]..
     permissions: groupmanager.mangaddp
   mangdelp:
     description: Removes permissions from a group.
-    usage: /<command> <group> <permissions>
+    usage: /<command> <group> <permission> [permission2] [permission3]..
     permissions: groupmanager.mangdelp
   mangclearp:
     description: Removes all permissions of a group.

--- a/EssentialsGroupManager/src/plugin.yml
+++ b/EssentialsGroupManager/src/plugin.yml
@@ -63,7 +63,7 @@ commands:
   mangclearp:
     description: Removes all permissions of a group.
     usage: /<command> <group> <permissions>
-    permissions: groupmanager.mangdelp
+    permissions: groupmanager.mangclearp
   manglistp:
     description: Lists all permissionss from a group.
     usage: /<command> <group>


### PR DESCRIPTION
when i put my Group Maneger i get in console a lot of erors: =============================== GM ERROR LOG ===============================
= ERROR REPORT START - 2.0 (2.12.1) (Phoenix) =

java.lang.IllegalArgumentException: The following file couldn't pass on Parser.
plugins\GroupManager\worlds\world\groups.yml
    at org.anjocaido.groupmanager.dataholder.WorldDataHolder.loadGroups(WorldDataHolder.java:496)
    at org.anjocaido.groupmanager.dataholder.WorldDataHolder.loadGroups(WorldDataHolder.java:416)
    at org.anjocaido.groupmanager.dataholder.worlds.WorldsHolder.loadWorld(WorldsHolder.java:678)
    at org.anjocaido.groupmanager.dataholder.worlds.WorldsHolder.loadWorld(WorldsHolder.java:640)
    at org.anjocaido.groupmanager.dataholder.worlds.WorldsHolder.initialWorldLoading(WorldsHolder.java:110)
    at org.anjocaido.groupmanager.dataholder.worlds.WorldsHolder.initialLoad(WorldsHolder.java:100)
    at org.anjocaido.groupmanager.dataholder.worlds.WorldsHolder.resetWorldsHolder(WorldsHolder.java:92)
    at org.anjocaido.groupmanager.dataholder.worlds.WorldsHolder.<init>(WorldsHolder.java:59)
    at org.anjocaido.groupmanager.GroupManager.onEnable(GroupManager.java:169)
    at org.anjocaido.groupmanager.GroupManager.onEnable(GroupManager.java:93)
    at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:217)
    at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:457)
    at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:381)
    at org.bukkit.craftbukkit.v1_7_R1.CraftServer.loadPlugin(CraftServer.java:298)
    at org.bukkit.craftbukkit.v1_7_R1.CraftServer.enablePlugins(CraftServer.java:280)
    at net.minecraft.server.v1_7_R1.MinecraftServer.m(MinecraftServer.java:338)
    at net.minecraft.server.v1_7_R1.MinecraftServer.g(MinecraftServer.java:315)
    at net.minecraft.server.v1_7_R1.MinecraftServer.a(MinecraftServer.java:275)
    at net.minecraft.server.v1_7_R1.DedicatedServer.init(DedicatedServer.java:175)
    at net.minecraft.server.v1_7_R1.MinecraftServer.run(MinecraftServer.java:420)
    at net.minecraft.server.v1_7_R1.ThreadServerApplication.run(SourceFile:617)
Caused by: while scanning for the next token
found character     '\t' that cannot start any token
 in "<reader>", line 86, column 1:

```
^

at org.yaml.snakeyaml.scanner.ScannerImpl.fetchMoreTokens(ScannerImpl.java:358)
at org.yaml.snakeyaml.scanner.ScannerImpl.checkToken(ScannerImpl.java:179)
at org.yaml.snakeyaml.parser.ParserImpl$ParseIndentlessSequenceEntry.produce(ParserImpl.java:535)
at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:161)
at org.yaml.snakeyaml.parser.ParserImpl.checkEvent(ParserImpl.java:146)
at org.yaml.snakeyaml.composer.Composer.composeSequenceNode(Composer.java:203)
at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:158)
at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:237)
at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:160)
at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:237)
at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:160)
at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:237)
at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:160)
at org.yaml.snakeyaml.composer.Composer.composeDocument(Composer.java:123)
at org.yaml.snakeyaml.composer.Composer.getSingleNode(Composer.java:106)
at org.yaml.snakeyaml.constructor.BaseConstructor.getSingleData(BaseConstructor.java:121)
at org.yaml.snakeyaml.Yaml.loadFromReader(Yaml.java:480)
at org.yaml.snakeyaml.Yaml.load(Yaml.java:423)
at org.anjocaido.groupmanager.dataholder.WorldDataHolder.loadGroups(WorldDataHolder.java:491)
... 20 more
```
# 
