### PR TITLE
fix: fireball_fire=true doesn't prevent fire from fireballs

### DIFF
--- a/EssentialsProtect/src/net/ess3/protect/EssentialsProtectBlockListener.java
+++ b/EssentialsProtect/src/net/ess3/protect/EssentialsProtectBlockListener.java
@@ -48,9 +48,15 @@ public class EssentialsProtectBlockListener implements Listener
 			event.setCancelled(settings.getData().getPrevent().isLavaFirespread());
 			return;
 		}
+		
 		if (event.getCause().equals(BlockIgniteEvent.IgniteCause.LIGHTNING))
 		{
 			event.setCancelled(settings.getData().getPrevent().isLightningFirespread());
+		}
+		
+		if (event.getCause().equals(BlockIgniteEvent.IgniteCause.FIREBALL))
+		{
+			event.setCancelled(settings.getData().getPrevent().isFireballFire());
 		}
 	}
 


### PR DESCRIPTION
I have added the condition to prevent fire spread from fireballs if it's specified on the config file.
