### PR TITLE
[Feature] Staff Chat similar to the one used in fCraft classic server software

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandstaffchat.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandstaffchat.java
@@ -1,0 +1,42 @@
+package com.earth2me.essentials.commands;
+
+import com.earth2me.essentials.CommandSource;
+import static com.earth2me.essentials.commands.EssentialsCommand.getFinalArg;
+import com.earth2me.essentials.utils.FormatUtil;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+
+
+public class Commandstaffchat extends EssentialsCommand
+{
+	public Commandstaffchat()
+	{
+		super("staffchat");
+	}
+
+	@Override
+	public void run(final Server server, final CommandSource sender, final String commandLabel, final String[] args) throws Exception
+	{
+		sendBroadcast(sender.getSender().getName(), server, sender, args);
+	}
+
+	private void sendBroadcast(final String name, final Server server, final CommandSource sender, final String[] args) throws NotEnoughArgumentsException
+	{
+		if (args.length < 1)
+		{
+			throw new NotEnoughArgumentsException();
+		}
+
+		for (Player onlinePlayer : server.getOnlinePlayers())
+		{
+			if (onlinePlayer.hasPermission("essentials.staffchat.read") && onlinePlayer != sender.getPlayer())
+			{
+				onlinePlayer.sendMessage("§b(Staff)" + name +"§b: " + FormatUtil.replaceFormat(getFinalArg(args, 0)).replace("\\n", "\n"));
+			}
+		}
+		sender.sendMessage("§b(Staff)" + name +"§b: " + FormatUtil.replaceFormat(getFinalArg(args, 0)).replace("\\n", "\n"));
+		Bukkit.getLogger().log(Level.INFO, ("(Staff)" + name +": " + FormatUtil.replaceFormat(getFinalArg(args, 0)).replace("\\n", "\n")));
+	}
+}

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -350,6 +350,10 @@ commands:
     description: Change your speed limits.
     usage: /<command> [type] <speed> [player]
     aliases: [flyspeed,eflyspeed,fspeed,efspeed,espeed,walkspeed,ewalkspeed,wspeed,ewspeed]
+  staffchat:
+    description: Sends a message only to staff members.
+    usage: /<command> <message>
+    aliases: [staff,st]
   sudo:
     description: Make another user perform a command.
     usage: /<command> <player> <command [args]>


### PR DESCRIPTION
Add essentials.staffchat to a group/user to allow them the ability to send a message to staff.
Add essentials.staffchat.read to a group/use to allow them the ability to see the messages being sent in staff chat.
Users that do not have permission to read staff chat will not see it at all.

![ScreenShot](http://i.imgur.com/fbNQjiy.png)
