### PR TITLE
[Fix] Finish Sentence

### DIFF
--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -660,7 +660,7 @@ protect:
 
     # Should people with build: false in permissions be allowed to use items?
     # Set true to disable using for those people.
-    # Setting to false means EssentialsAntiBuild will never prevent you from using.
+    # Setting to false means EssentialsAntiBuild will never prevent you from using items.
     use: true
 
     # Should we tell people they are not allowed to build?


### PR DESCRIPTION
Setting to false means EssentialsAntiBuild will never prevent you from using.
->
Setting to false means EssentialsAntiBuild will never prevent you from using items.

 It is a privilege to make such a profound change to the source code.
