### PR TITLE
Add mail verification/confirmation in chat

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -75,6 +75,8 @@ public class Commandmail extends EssentialsCommand
 				u.addMail(mail);
 			}
 			user.sendMessage(_("mailSent"));
+			user.sendMessage(_("mailMessage"));
+			user.sendMessage(mail);
 			return;
 		}
 		if (args.length > 1 && "sendall".equalsIgnoreCase(args[0]))

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -227,6 +227,7 @@ localFormat=[L]<{0}> {1}
 mailClear=\u00a76To mark your mail as read, type\u00a7c /mail clear.
 mailCleared=\u00a76Mail Cleared\!
 mailSent=\u00a76Mail sent\!
+mailMessage=\u00a77You sent a mail to {1} with the message:
 markMailAsRead=\u00a76To mark your mail as read, type\u00a7c /mail clear.
 markedAsAway=\u00a76You are now marked as away.
 markedAsNotAway=\u00a76You are no longer marked as away.


### PR DESCRIPTION
http://www.ecocitycraft.com/forum/threads/suggestion-mail.86067/
Not entirely mandatory to be added, and could be tweaked with a config option.
Here is the original message, from the above link.

"Minecraft Name: AgentHare

Suggestion: To have the command come back with Mail Sent to _________________: _message you sent to them_

Reason: Is very useful for getting solid evidence of you /mail ing a user to get out of your town, or other things. Could be useful for mayors or to make sure you said everything you wanted to.

Link To This Plugin: could be added?"
