### PR TITLE
Enchance UserBalanceUpdateEvent

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -460,8 +460,9 @@ public class User extends UserData implements Comparable<User>, IReplyTo, net.es
 			{
 			}
 		}
+		BigDecimal oldValue = getMoney();
 		super.setMoney(value, true);
-		ess.getServer().getPluginManager().callEvent(new UserBalanceUpdateEvent(this.getBase(), value));
+		ess.getServer().getPluginManager().callEvent(new UserBalanceUpdateEvent(this, value, oldValue));
 		Trade.log("Update", "Set", "API", getName(), new Trade(value, ess), null, null, null, ess);
 	}
 

--- a/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
@@ -2,6 +2,7 @@ package net.ess3.api.events;
 
 import java.math.BigDecimal;
 
+import com.earth2me.essentials.IUser;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -10,13 +11,15 @@ import org.bukkit.event.HandlerList;
 public class UserBalanceUpdateEvent extends Event
 {
 	private static final HandlerList handlers = new HandlerList();
-	private final Player player;
-	private final BigDecimal balance;
+	private final IUser user;
+	private BigDecimal newBalance;
+	private BigDecimal oldBalance;
 
-	public UserBalanceUpdateEvent(Player player, BigDecimal balance)
+	public UserBalanceUpdateEvent(IUser user, BigDecimal newBalance, BigDecimal oldBalance)
 	{
-		this.player = player;
-		this.balance = balance;
+		this.user = user;
+		this.newBalance = newBalance;
+		this.oldBalance = oldBalance;
 	}
 
 	@Override
@@ -32,11 +35,24 @@ public class UserBalanceUpdateEvent extends Event
 
 	public Player getPlayer()
 	{
-		return player;
+		return user.getBase();
+	}
+
+	public IUser getUser() {
+		return user;
 	}
 
 	public BigDecimal getNewBalance()
 	{
-		return balance;
+		return newBalance;
+	}
+
+	public BigDecimal getOldBalance()
+	{
+		return oldBalance;
+	}
+
+	public BigDecimal getChange() {
+		return newBalance.subtract(getOldBalance());
 	}
 }


### PR DESCRIPTION
Event handlers can now access the old balance and modify the new

Fully API-compatible except for a change in the constructor
