### PR TITLE
Add Java8 Support (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6


### PR DESCRIPTION
> Reopen when Java8 will be released. ~ https://github.com/essentials/Essentials/pull/616#issuecomment-31586081

Yesterday Java 8 has been released! Finally!
Please close this pull if build fails.
