### PR TITLE
Allowing Korean characters in /nick command

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
@@ -86,7 +86,8 @@ public class Commandnick extends EssentialsLoopCommand
 	private String formatNickname(final User user, final String nick) throws Exception
 	{
 		String newNick = user == null ? FormatUtil.replaceFormat(nick) : FormatUtil.formatString(user, "essentials.nick", nick);
-		if (!newNick.matches("^[a-zA-Z_0-9\u00a7]+$"))
+		// if (!newNick.matches("^[a-zA-Z_0-9\u00a7]+$")) /* Original Regex */
+		if (!newNick.matches("^[a-zA-Z_0-9\u00a7ㄱ-ㆆㄱ-ㆎ가-힣]+$"))
 		{
 			throw new Exception(tl("nickNamesAlpha"));
 		}


### PR DESCRIPTION
Korean users want to use Korean Nickname via Essentials's /nick command.
but Original Essentials /nick command doesn't have Korean Regex.

Please accept it :)
