### PR TITLE
[Fix] Add permission check before resetting speed on login

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -331,8 +331,11 @@ public class EssentialsPlayerListener implements Listener
 						user.getBase().sendMessage(tl("flyMode", tl("enabled"), user.getDisplayName()));
 					}
 				}
-				user.getBase().setFlySpeed(0.1f);
-				user.getBase().setWalkSpeed(0.2f);
+
+				if (!user.isAuthorized("essentials.speed")) {
+					user.getBase().setFlySpeed(0.1f);
+					user.getBase().setWalkSpeed(0.2f);
+				}
 
 				user.stopTransaction();
 			}


### PR DESCRIPTION
The staff of my server asked me to do this fix, but I think it is very useful for all. This commit change is to reset player fly & run speed only if player has no permission to change speed.
