### PR TITLE
ESS-5738: Essentials signs can be broken via retracting sticky piston

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
@@ -271,22 +271,32 @@ public class SignBlockListener implements Listener
 
 		if (event.isSticky())
 		{
-			final Block block = event.getBlock();
-			if (((block.getType() == WALL_SIGN
-				  || block.getType() == SIGN_POST)
-				 && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block)))
-				|| EssentialsSign.checkIfBlockBreaksSigns(block))
+			final Block pistonBaseBlock = event.getBlock();
+			final Block[] affectedBlocks = new Block[]
+				{
+					pistonBaseBlock,
+					pistonBaseBlock.getRelative(event.getDirection()),
+					event.getRetractLocation().getBlock()
+				};
+			
+			for (Block block : affectedBlocks)
 			{
-				event.setCancelled(true);
-				return;
-			}
-			for (EssentialsSign sign : ess.getSettings().enabledSigns())
-			{
-				if (sign.areHeavyEventRequired() && sign.getBlocks().contains(block.getType())
-					&& !sign.onBlockPush(block, ess))
+				if (((block.getType() == WALL_SIGN
+					  || block.getType() == SIGN_POST)
+					 && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block)))
+					|| EssentialsSign.checkIfBlockBreaksSigns(block))
 				{
 					event.setCancelled(true);
 					return;
+				}
+				for (EssentialsSign sign : ess.getSettings().enabledSigns())
+				{
+					if (sign.areHeavyEventRequired() && sign.getBlocks().contains(block.getType())
+						&& !sign.onBlockPush(block, ess))
+					{
+						event.setCancelled(true);
+						return;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes ESS-5738 (https://essentials3.atlassian.net/browse/ESS-5738).

Sticky pistons could break signs that were mounted on blocks the pistons were retracting.

This patch extends the protection from just the piston base to include the extended piston arm and the block at the end of the piston arm as well.

This method will very likely need to be changed again when 1.8 comes out, but this should bring us a bit closer, by wrapping the block tests in a loop.
