### PR TITLE
Do not override PlayerRespawnEvent location if no group data is found.

### DIFF
--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
@@ -62,10 +62,14 @@ public class EssentialsSpawnPlayerListener implements Listener
 				return;
 			}
 		}
-		final Location spawn = spawns.getSpawn(user.getGroup());
-		if (spawn != null)
+
+		if (spawns.getData().getSpawns() != null && user.getGroup() != null)
 		{
-			event.setRespawnLocation(spawn);
+			final Location spawn = spawns.getSpawn(user.getGroup());
+			if (spawn != null)
+			{
+				event.setRespawnLocation(spawn);
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, if no group data is found, the PlayerListener for PlayerRespawnEvent will override the event's location and set it to overworld's spawnpoint. Instead, if no group data is found, we simply ignore it as nothing needs to change.
