### PR TITLE
[Fix] Adding support for colored mails. Update of #770.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -106,7 +106,7 @@ public class Commandmail extends EssentialsCommand
 			{
 				throw new Exception(tl("noPerm", "essentials.mail.sendall"));
 			}
-			ess.runTaskAsynchronously(new SendAll(tl("mailFormat", user.getName(), FormatUtil.replaceFormat(getFinalArg(args, 1)))));
+			ess.runTaskAsynchronously(new SendAll(tl("mailFormat", user.getName(), FormatUtil.replaceFormat(getFinalArg(args, 2)))));
 			user.sendMessage(tl("mailSent"));
 			return;
 		}

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -64,7 +64,7 @@ public class Commandmail extends EssentialsCommand
 				throw new Exception(tl("playerNeverOnServer", args[1]));
 			}
 			
-			if (!user.isAuthorized("essentials.mail.send.color"))
+			if (!user.isAuthorized("essentials.mail.send.color") && !user.isAuthorized("essentials.mail.send.colour"))
 			{
 				final String mail = tl("mailFormat", user.getName(), StringUtil.sanitizeString(FormatUtil.stripFormat(getFinalArg(args, 2))));
 				if (mail.length() > 1000)

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -63,11 +63,22 @@ public class Commandmail extends EssentialsCommand
 			{
 				throw new Exception(tl("playerNeverOnServer", args[1]));
 			}
-
-			final String mail = tl("mailFormat", user.getName(), StringUtil.sanitizeString(FormatUtil.stripFormat(getFinalArg(args, 2))));
-			if (mail.length() > 1000)
+			
+			if (!user.isAuthorized("essentials.mail.send.color"))
 			{
-				throw new Exception(tl("mailTooLong"));
+				final String mail = tl("mailFormat", user.getName(), StringUtil.sanitizeString(FormatUtil.stripFormat(getFinalArg(args, 2))));
+				if (mail.length() > 1000)
+				{
+					throw new Exception(tl("mailTooLong"));
+				}
+			}
+			else
+			{
+				final String mail = tl("mailFormat", user.getName(), StringUtil.sanitizeString(FormatUtil.replaceFormat(getFinalArg(args, 2))));
+				if (mail.length() > 1000)
+				{
+					throw new Exception(tl("mailTooLong"));
+				}
 			}
 
 			if (!u.isIgnoredPlayer(user))

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -74,7 +74,7 @@ public class Commandmail extends EssentialsCommand
 			}
 			else
 			{
-				final String mail = tl("mailFormat", user.getName(), StringUtil.sanitizeString(FormatUtil.replaceFormat(getFinalArg(args, 2))));
+				final String mail = tl("mailFormat", user.getName(), FormatUtil.replaceFormat(getFinalArg(args, 2)));
 				if (mail.length() > 1000)
 				{
 					throw new Exception(tl("mailTooLong"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -106,7 +106,7 @@ public class Commandmail extends EssentialsCommand
 			{
 				throw new Exception(tl("noPerm", "essentials.mail.sendall"));
 			}
-			ess.runTaskAsynchronously(new SendAll(tl("mailFormat", user.getName(), FormatUtil.stripFormat(getFinalArg(args, 1)))));
+			ess.runTaskAsynchronously(new SendAll(tl("mailFormat", user.getName(), FormatUtil.replaceFormat(getFinalArg(args, 1)))));
 			user.sendMessage(tl("mailSent"));
 			return;
 		}


### PR DESCRIPTION
Attempting to fix the compilation failure with my previous PR, #770.
#770 was a minor improvement upon the mail feature that adds the ability for colored mails to be sent. It was a quick fix, and I think it was pretty self-explanatory. I will note that FormatUtil.stripFormat removes all formatting, and FormatUtil.replaceFormat replaces all formatting with §-style (Minecraft) color codes. If the user has permission to send colored mails, then the mail will be stored with §-style (Minecraft) color codes.
