### PR TITLE
Try to recklessly squash a permission issue in Essentials

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
@@ -140,6 +140,12 @@ public class SignBlockListener implements Listener
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onSignBlockPlace(final BlockPlaceEvent event)
 	{
+		if (!(user.isAuthorized("essentials.signs." + signName.toLowerCase(Locale.ENGLISH) + ".create")
+			  || !user.isAuthorized("essentials.signs.create." + signName.toLowerCase(Locale.ENGLISH))))
+			  {
+			  	return;
+			  	//Sanity-permission check
+			  }
 		if (ess.getSettings().areSignsDisabled())
 		{
 			event.getHandlers().unregister(this);


### PR DESCRIPTION
if you put selection marks on signs you can bypass the permission check. this should hopefully patch this.
